### PR TITLE
Add progress indicator for mobile photo uploads

### DIFF
--- a/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.html
+++ b/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.html
@@ -16,6 +16,8 @@
     </button>
   </div>
 
+  <mat-progress-bar *ngIf="uploadProgress !== null" [mode]="progressMode" [value]="uploadProgress"></mat-progress-bar>
+
   <div class="last-shot" *ngIf="photoDataUrl">
     <img [src]="photoDataUrl" alt="snapshot" />
   </div>

--- a/mobile/calorie-counter/src/app/services/foodbot-api.service.ts
+++ b/mobile/calorie-counter/src/app/services/foodbot-api.service.ts
@@ -1,5 +1,5 @@
 ﻿import { Injectable } from "@angular/core";
-import { HttpClient, HttpParams } from "@angular/common/http";
+import { HttpClient, HttpParams, HttpEvent } from "@angular/common/http";
 import { map, Observable } from "rxjs";
 import { FoodBotAuthLinkService } from "./foodbot-auth-link.service";
 import {
@@ -30,10 +30,14 @@ export class FoodbotApiService {
   }
 
   // Загрузка фото
-  uploadPhoto(file: File): Observable<UploadResult> {
+  uploadPhoto(file: File): Observable<HttpEvent<UploadResult>> {
     const form = new FormData();
     form.append("image", file, file.name);
-    return this.http.post<UploadResult>(`${this.baseUrl}/api/meals/upload`, form);
+    return this.http.post<UploadResult>(
+      `${this.baseUrl}/api/meals/upload`,
+      form,
+      { reportProgress: true, observe: "events" }
+    );
   }
 
   // Уточнения


### PR DESCRIPTION
## Summary
- enable progress events in mobile upload API service
- show progress bar when uploading and processing photos

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68aede86d8248331823db3e0a5b412ef