### PR TITLE
feat: add daily stats view

### DIFF
--- a/mobile/calorie-counter/src/app/app.component.html
+++ b/mobile/calorie-counter/src/app/app.component.html
@@ -4,6 +4,7 @@
   <a mat-icon-button aria-label="История" routerLink="/history"><mat-icon>history</mat-icon></a>
   <a mat-icon-button aria-label="Добавить" routerLink="/add"><mat-icon>add_a_photo</mat-icon></a>
   <a mat-icon-button aria-label="Анализ" routerLink="/analysis"><mat-icon>analytics</mat-icon></a>
+  <a mat-icon-button aria-label="Статистика" routerLink="/stats"><mat-icon>bar_chart</mat-icon></a>
 </mat-toolbar>
 
 <div class="container">

--- a/mobile/calorie-counter/src/app/pages/stats/stats.page.html
+++ b/mobile/calorie-counter/src/app/pages/stats/stats.page.html
@@ -1,0 +1,62 @@
+<mat-card>
+  <h3>Статистика по дням</h3>
+
+  <mat-form-field appearance="fill">
+    <mat-label>Период</mat-label>
+    <mat-select [(ngModel)]="selectedPeriod" (selectionChange)="updatePeriod()">
+      <mat-option value="week">Неделя</mat-option>
+      <mat-option value="month">Месяц</mat-option>
+      <mat-option value="quarter">Квартал</mat-option>
+      <mat-option value="custom">Пользовательский</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <div class="dates" *ngIf="selectedPeriod==='custom'">
+    <input type="date" [(ngModel)]="customStart" (change)="updatePeriod()">
+    <input type="date" [(ngModel)]="customEnd" (change)="updatePeriod()">
+  </div>
+
+  <mat-button-toggle-group [(ngModel)]="view">
+    <mat-button-toggle value="chart">График</mat-button-toggle>
+    <mat-button-toggle value="table">Таблица</mat-button-toggle>
+  </mat-button-toggle-group>
+
+  <ng-container *ngIf="view==='chart'">
+    <div class="day-bar" *ngFor="let d of data">
+      <div class="label">{{ d.date | date:'dd.MM' }}</div>
+      <div class="bar-wrapper">
+        <div class="bar-fill" [style.width.%]="maxCalories ? (d.totals.calories / maxCalories) * 100 : 0"></div>
+      </div>
+      <div class="details">{{ d.totals.calories | number:'1.0-0' }} ккал · Б {{ d.totals.proteins | number:'1.0-0' }} · Ж {{ d.totals.fats | number:'1.0-0' }} · У {{ d.totals.carbs | number:'1.0-0' }}</div>
+    </div>
+  </ng-container>
+
+  <ng-container *ngIf="view==='table'">
+    <table class="stats-table">
+      <thead>
+        <tr><th>Дата</th><th>Ккал</th><th>Б</th><th>Ж</th><th>У</th></tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let d of data">
+          <td>{{ d.date | date:'dd.MM' }}</td>
+          <td>{{ d.totals.calories | number:'1.0-0' }}</td>
+          <td>{{ d.totals.proteins | number:'1.0-0' }}</td>
+          <td>{{ d.totals.fats | number:'1.0-0' }}</td>
+          <td>{{ d.totals.carbs | number:'1.0-0' }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </ng-container>
+</mat-card>
+
+<style>
+.dates { display: flex; gap: 8px; margin: 8px 0; }
+.day-bar { margin: 8px 0; }
+.bar-wrapper { background: rgba(0,0,0,.1); height: 8px; width: 100%; }
+.bar-fill { background: #3f51b5; height: 100%; }
+.label { font-weight: bold; margin-bottom: 4px; }
+.details { font-size: 12px; margin-top: 4px; }
+.stats-table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+.stats-table th, .stats-table td { border: 1px solid rgba(0,0,0,.1); padding: 4px; text-align: right; }
+.stats-table th:first-child, .stats-table td:first-child { text-align: left; }
+</style>

--- a/mobile/calorie-counter/src/app/pages/stats/stats.page.scss
+++ b/mobile/calorie-counter/src/app/pages/stats/stats.page.scss
@@ -1,0 +1,1 @@
+:host { display: block; }

--- a/mobile/calorie-counter/src/app/pages/stats/stats.page.ts
+++ b/mobile/calorie-counter/src/app/pages/stats/stats.page.ts
@@ -1,0 +1,48 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MealService } from '../../services/meal.service';
+
+interface DayTotals {
+  date: Date;
+  totals: { calories: number; proteins: number; fats: number; carbs: number };
+}
+
+@Component({
+  selector: 'app-stats',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MatCardModule, MatButtonToggleModule, MatFormFieldModule, MatSelectModule],
+  templateUrl: './stats.page.html',
+  styleUrls: ['./stats.page.scss']
+})
+export class StatsPage implements OnInit {
+  view: 'chart' | 'table' = 'chart';
+  selectedPeriod = 'week';
+  customStart = '';
+  customEnd = '';
+  data: DayTotals[] = [];
+  maxCalories = 0;
+
+  constructor(private meals: MealService) {}
+
+  ngOnInit() { this.updatePeriod(); }
+
+  updatePeriod() {
+    const end = new Date();
+    end.setHours(0,0,0,0);
+    let start = new Date(end);
+    if (this.selectedPeriod === 'week') start.setDate(end.getDate() - 6);
+    else if (this.selectedPeriod === 'month') start.setDate(end.getDate() - 29);
+    else if (this.selectedPeriod === 'quarter') start.setDate(end.getDate() - 89);
+    else {
+      if (this.customStart) start = new Date(this.customStart);
+      if (this.customEnd) end.setTime(new Date(this.customEnd).getTime());
+    }
+    this.data = this.meals.dailyTotals(start, end);
+    this.maxCalories = Math.max(0, ...this.data.map(d => d.totals.calories));
+  }
+}

--- a/mobile/calorie-counter/src/app/routes.ts
+++ b/mobile/calorie-counter/src/app/routes.ts
@@ -3,6 +3,7 @@ import { HistoryPage } from "./pages/history/history.page";
 import { AddMealPage } from "./pages/add-meal/add-meal.page";
 import { AnalysisPage } from "./pages/analysis/analysis.page";
 import { AuthPage } from "./pages/auth/auth.page";
+import { StatsPage } from "./pages/stats/stats.page";
 import { authGuard } from "./guards/auth.guard";
 
 export const routes: Routes = [
@@ -11,5 +12,6 @@ export const routes: Routes = [
   { path: "history", component: HistoryPage, canActivate: [authGuard] },
   { path: "add", component: AddMealPage, canActivate: [authGuard] },
   { path: "analysis", component: AnalysisPage, canActivate: [authGuard] },
+  { path: "stats", component: StatsPage, canActivate: [authGuard] },
   { path: "**", redirectTo: "history" }
 ];

--- a/mobile/calorie-counter/src/app/services/meal.service.ts
+++ b/mobile/calorie-counter/src/app/services/meal.service.ts
@@ -60,6 +60,18 @@ export class MealService {
     return this.sumRange(start, end);
   }
 
+  dailyTotals(start: Date, end: Date) {
+    const results: { date: Date; totals: { calories: number; proteins: number; fats: number; carbs: number } }[] = [];
+    const dayMs = 24 * 60 * 60 * 1000;
+    const s = new Date(start); s.setHours(0, 0, 0, 0);
+    const e = new Date(end); e.setHours(0, 0, 0, 0);
+    for (let t = s.getTime(); t <= e.getTime(); t += dayMs) {
+      const { totals } = this.sumRange(t, t + dayMs - 1);
+      results.push({ date: new Date(t), totals });
+    }
+    return results;
+  }
+
   private sumRange(startMs: number, endMs: number) {
     const meals = this._meals$.value.filter(m => m.timestamp >= startMs && m.timestamp <= endMs);
     const totals = meals.reduce((acc, m) => {


### PR DESCRIPTION
## Summary
- add stats tab with chart and table views of daily calories and macros
- allow selecting predefined or custom periods

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: app.component.spec.ts: Unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68aeeb4839e483318134bdae1af1e3d9