### PR TITLE
Add server stats endpoint and client service for nutrient tracking

### DIFF
--- a/FoodBot/Controllers/StatsController.cs
+++ b/FoodBot/Controllers/StatsController.cs
@@ -1,0 +1,31 @@
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using FoodBot.Services;
+
+namespace FoodBot.Controllers;
+
+[ApiController]
+[Route("api/stats")]
+[Authorize(AuthenticationSchemes = "Bearer")]
+public sealed class StatsController : ControllerBase
+{
+    private readonly StatsService _stats;
+
+    public StatsController(StatsService stats)
+    {
+        _stats = stats;
+    }
+
+    private long GetChatId() =>
+        long.TryParse(User.FindFirstValue("chat_id"), out var id) ? id : throw new UnauthorizedAccessException();
+
+    [HttpGet("summary")]
+    public Task<StatsSummary> Summary([FromQuery] int days = 1, CancellationToken ct = default)
+    {
+        days = Math.Clamp(days, 1, 30);
+        return _stats.GetSummaryAsync(GetChatId(), days, ct);
+    }
+}

--- a/FoodBot/Program.cs
+++ b/FoodBot/Program.cs
@@ -50,6 +50,7 @@ builder.Services.AddSingleton<NutritionService>(sp =>
 
 builder.Services.AddSingleton<SpeechToTextService>();
 builder.Services.AddScoped<TelegramReportService>();
+builder.Services.AddScoped<StatsService>();
 
 // ===== Controllers / API =====
 builder.Services.AddControllers(); // AppAuthController / MealsController

--- a/FoodBot/Services/StatsService.cs
+++ b/FoodBot/Services/StatsService.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using FoodBot.Data;
+
+namespace FoodBot.Services;
+
+public sealed class StatsService
+{
+    private readonly BotDbContext _db;
+
+    public StatsService(BotDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<StatsSummary> GetSummaryAsync(long chatId, int days, CancellationToken ct = default)
+    {
+        if (days <= 0) days = 1;
+        var from = DateTimeOffset.UtcNow.Date.AddDays(-(days - 1));
+        var to = DateTimeOffset.UtcNow;
+
+        var totals = await _db.Meals
+            .AsNoTracking()
+            .Where(m => m.ChatId == chatId && m.CreatedAtUtc >= from && m.CreatedAtUtc <= to)
+            .GroupBy(_ => 1)
+            .Select(g => new
+            {
+                Calories = g.Sum(m => m.CaloriesKcal) ?? 0,
+                Proteins = g.Sum(m => m.ProteinsG) ?? 0,
+                Fats = g.Sum(m => m.FatsG) ?? 0,
+                Carbs = g.Sum(m => m.CarbsG) ?? 0,
+                Count = g.Count()
+            })
+            .FirstOrDefaultAsync(ct);
+
+        if (totals == null)
+        {
+            return new StatsSummary
+            {
+                Totals = new MacroTotals(),
+                Days = days,
+                Entries = 0
+            };
+        }
+
+        return new StatsSummary
+        {
+            Totals = new MacroTotals
+            {
+                Calories = totals.Calories,
+                Proteins = totals.Proteins,
+                Fats = totals.Fats,
+                Carbs = totals.Carbs
+            },
+            Days = days,
+            Entries = totals.Count
+        };
+    }
+}
+
+public sealed class StatsSummary
+{
+    public required MacroTotals Totals { get; set; }
+    public int Days { get; set; }
+    public int Entries { get; set; }
+}
+
+public sealed class MacroTotals
+{
+    public decimal Calories { get; set; }
+    public decimal Proteins { get; set; }
+    public decimal Fats { get; set; }
+    public decimal Carbs { get; set; }
+}
+

--- a/mobile/calorie-counter/src/app/services/stats.service.ts
+++ b/mobile/calorie-counter/src/app/services/stats.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { FoodBotAuthLinkService } from './foodbot-auth-link.service';
+
+export interface MacroTotals {
+  calories: number;
+  proteins: number;
+  fats: number;
+  carbs: number;
+}
+
+export interface StatsSummary {
+  totals: MacroTotals;
+  days: number;
+  entries: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class StatsService {
+  constructor(private http: HttpClient, private auth: FoodBotAuthLinkService) {}
+  private get baseUrl(): string { return this.auth.apiBaseUrl; }
+
+  getSummary(days = 1): Observable<StatsSummary> {
+    const params = new HttpParams().set('days', days);
+    return this.http.get<StatsSummary>(`${this.baseUrl}/api/stats/summary`, { params });
+  }
+}


### PR DESCRIPTION
## Summary
- add StatsService to compute per-user macro totals
- expose `/api/stats/summary` controller
- register stats service in DI and add Angular client service for summaries

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `npm test` *(fails: No binary for Chrome browser on your platform)*


------
https://chatgpt.com/codex/tasks/task_e_68aeed9bb4708331a52a90839c0de1ff