### PR TITLE
Fix meal listing with empty image field and include full day in stats

### DIFF
--- a/FoodBot/Controllers/MealsApiController.cs
+++ b/FoodBot/Controllers/MealsApiController.cs
@@ -69,7 +69,7 @@ namespace FoodBot.Controllers
                     m.CarbsG,
                     m.IngredientsJson,
                     m.ProductsJson,
-                    HasImage = m.ImageBytes != null && m.ImageBytes.Length > 0
+                    HasImage = EF.Functions.DataLength(m.ImageBytes) > 0
                 })
                 .ToListAsync(ct);
 

--- a/FoodBot/Services/StatsService.cs
+++ b/FoodBot/Services/StatsService.cs
@@ -20,11 +20,11 @@ public sealed class StatsService
     {
         if (days <= 0) days = 1;
         var from = DateTimeOffset.UtcNow.Date.AddDays(-(days - 1));
-        var to = DateTimeOffset.UtcNow;
+        var to = DateTimeOffset.UtcNow.Date.AddDays(1);
 
         var totals = await _db.Meals
             .AsNoTracking()
-            .Where(m => m.ChatId == chatId && m.CreatedAtUtc >= from && m.CreatedAtUtc <= to)
+            .Where(m => m.ChatId == chatId && m.CreatedAtUtc >= from && m.CreatedAtUtc < to)
             .GroupBy(_ => 1)
             .Select(g => new
             {


### PR DESCRIPTION
## Summary
- Use `EF.Functions.DataLength` to compute `HasImage` so records remain visible even when images are missing
- Adjust stats date range to cover the entire current day

## Testing
- `dotnet test` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68aef384a0d483318d029a4d5455a716