### PR TITLE
Handle missing product details safely

### DIFF
--- a/FoodBot/Services/ProductJsonHelper.cs
+++ b/FoodBot/Services/ProductJsonHelper.cs
@@ -7,14 +7,14 @@ namespace FoodBot.Services;
 
 public static class ProductJsonHelper
 {
-    public static string? BuildProductsJson(string? calcPlanJson)
+    public static string BuildProductsJson(string? calcPlanJson)
     {
-        if (string.IsNullOrWhiteSpace(calcPlanJson)) return null;
+        if (string.IsNullOrWhiteSpace(calcPlanJson)) return "[]";
         try
         {
             var final = JsonSerializer.Deserialize<FinalPayload>(calcPlanJson,
                 new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-            if (final?.per_ingredient == null) return null;
+            if (final?.per_ingredient == null) return "[]";
             var total = final.weight_g > 0 ? final.weight_g : final.per_ingredient.Sum(p => p.grams);
             var parts = final.per_ingredient.Select(p => new ProductInfo
             {
@@ -30,7 +30,7 @@ public static class ProductJsonHelper
         }
         catch
         {
-            return null;
+            return "[]";
         }
     }
 


### PR DESCRIPTION
## Summary
- Always serialize an empty array when product calculation data is missing or invalid
- Ensure JSON deserialization for products gracefully falls back to an empty list

## Testing
- `dotnet build FoodBot/FoodBot.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68aef6fb1da083319c64739425b7c86d