### PR TITLE
Serve daily stats through API and improve chart axis

### DIFF
--- a/FoodBot/Controllers/StatsController.cs
+++ b/FoodBot/Controllers/StatsController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,5 +28,11 @@ public sealed class StatsController : ControllerBase
     {
         days = Math.Clamp(days, 1, 30);
         return _stats.GetSummaryAsync(GetChatId(), days, ct);
+    }
+
+    [HttpGet("daily")]
+    public Task<List<DailyTotals>> Daily([FromQuery] DateTime from, [FromQuery] DateTime to, CancellationToken ct = default)
+    {
+        return _stats.GetDailyTotalsAsync(GetChatId(), from, to, ct);
     }
 }

--- a/mobile/calorie-counter/src/app/pages/stats/stats.page.html
+++ b/mobile/calorie-counter/src/app/pages/stats/stats.page.html
@@ -22,12 +22,13 @@
   </mat-button-toggle-group>
 
   <ng-container *ngIf="view==='chart'">
-    <div class="day-bar" *ngFor="let d of data">
-      <div class="label">{{ d.date | date:'dd.MM' }}</div>
-      <div class="bar-wrapper">
-        <div class="bar-fill" [style.width.%]="maxCalories ? (d.totals.calories / maxCalories) * 100 : 0"></div>
+    <div class="chart">
+      <div class="bars">
+        <div class="bar" *ngFor="let d of data" [style.height.%]="maxCalories ? (d.totals.calories / maxCalories) * 100 : 0"></div>
       </div>
-      <div class="details">{{ d.totals.calories | number:'1.0-0' }} ккал · Б {{ d.totals.proteins | number:'1.0-0' }} · Ж {{ d.totals.fats | number:'1.0-0' }} · У {{ d.totals.carbs | number:'1.0-0' }}</div>
+      <div class="labels">
+        <div class="label" *ngFor="let d of data">{{ d.date | date:'dd.MM' }}</div>
+      </div>
     </div>
   </ng-container>
 
@@ -51,11 +52,11 @@
 
 <style>
 .dates { display: flex; gap: 8px; margin: 8px 0; }
-.day-bar { margin: 8px 0; }
-.bar-wrapper { background: rgba(0,0,0,.1); height: 8px; width: 100%; }
-.bar-fill { background: #3f51b5; height: 100%; }
-.label { font-weight: bold; margin-bottom: 4px; }
-.details { font-size: 12px; margin-top: 4px; }
+.chart { height: 200px; display: flex; flex-direction: column; }
+.bars { flex: 1; display: flex; align-items: flex-end; gap: 4px; }
+.bar { flex: 1; background: #3f51b5; }
+.labels { display: flex; gap: 4px; }
+.label { flex: 1; text-align: center; font-size: 12px; }
 .stats-table { width: 100%; border-collapse: collapse; margin-top: 8px; }
 .stats-table th, .stats-table td { border: 1px solid rgba(0,0,0,.1); padding: 4px; text-align: right; }
 .stats-table th:first-child, .stats-table td:first-child { text-align: left; }

--- a/mobile/calorie-counter/src/app/pages/stats/stats.page.ts
+++ b/mobile/calorie-counter/src/app/pages/stats/stats.page.ts
@@ -5,12 +5,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
-import { MealService } from '../../services/meal.service';
-
-interface DayTotals {
-  date: Date;
-  totals: { calories: number; proteins: number; fats: number; carbs: number };
-}
+import { StatsService, DayStats } from '../../services/stats.service';
 
 @Component({
   selector: 'app-stats',
@@ -24,10 +19,10 @@ export class StatsPage implements OnInit {
   selectedPeriod = 'week';
   customStart = '';
   customEnd = '';
-  data: DayTotals[] = [];
+  data: { date: Date; totals: { calories: number; proteins: number; fats: number; carbs: number } }[] = [];
   maxCalories = 0;
 
-  constructor(private meals: MealService) {}
+  constructor(private stats: StatsService) {}
 
   ngOnInit() { this.updatePeriod(); }
 
@@ -42,7 +37,9 @@ export class StatsPage implements OnInit {
       if (this.customStart) start = new Date(this.customStart);
       if (this.customEnd) end.setTime(new Date(this.customEnd).getTime());
     }
-    this.data = this.meals.dailyTotals(start, end);
-    this.maxCalories = Math.max(0, ...this.data.map(d => d.totals.calories));
+    this.stats.getDaily(start, end).subscribe(res => {
+      this.data = res.map(d => ({ date: new Date(d.date), totals: d.totals }));
+      this.maxCalories = Math.max(0, ...this.data.map(d => d.totals.calories));
+    });
   }
 }

--- a/mobile/calorie-counter/src/app/services/stats.service.ts
+++ b/mobile/calorie-counter/src/app/services/stats.service.ts
@@ -16,6 +16,11 @@ export interface StatsSummary {
   entries: number;
 }
 
+export interface DayStats {
+  date: string;
+  totals: MacroTotals;
+}
+
 @Injectable({ providedIn: 'root' })
 export class StatsService {
   constructor(private http: HttpClient, private auth: FoodBotAuthLinkService) {}
@@ -24,5 +29,12 @@ export class StatsService {
   getSummary(days = 1): Observable<StatsSummary> {
     const params = new HttpParams().set('days', days);
     return this.http.get<StatsSummary>(`${this.baseUrl}/api/stats/summary`, { params });
+  }
+
+  getDaily(from: Date, to: Date): Observable<DayStats[]> {
+    const params = new HttpParams()
+      .set('from', from.toISOString().split('T')[0])
+      .set('to', to.toISOString().split('T')[0]);
+    return this.http.get<DayStats[]>(`${this.baseUrl}/api/stats/daily`, { params });
   }
 }


### PR DESCRIPTION
## Summary
- expose `/api/stats/daily` endpoint returning per-day macro totals
- fetch stats from API in mobile app and render vertical bar chart with date axis

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `npm test` *(fails: TS compilation errors in app.component.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68af00e4aad88331bf8094d1b01ad723