### PR TITLE
Fix grouping by date for daily totals

### DIFF
--- a/FoodBot/Services/StatsService.cs
+++ b/FoodBot/Services/StatsService.cs
@@ -69,7 +69,7 @@ public sealed class StatsService
         var results = await _db.Meals
             .AsNoTracking()
             .Where(m => m.ChatId == chatId && m.CreatedAtUtc >= start && m.CreatedAtUtc < end)
-            .GroupBy(m => m.CreatedAtUtc.UtcDateTime.Date)
+            .GroupBy(m => m.CreatedAtUtc.Date)
             .Select(g => new DailyTotals
             {
                 Date = g.Key,


### PR DESCRIPTION
## Summary
- Fix stats query by grouping meals using EF-translatable Date property

## Testing
- `dotnet build FoodBot/FoodBot.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68af4ad99630833196e5200127bc20cc