### PR TITLE
Trim empty days from daily stats

### DIFF
--- a/FoodBot/Services/StatsService.cs
+++ b/FoodBot/Services/StatsService.cs
@@ -89,7 +89,15 @@ public sealed class StatsService
             var item = results.FirstOrDefault(r => r.Date == day);
             list.Add(item ?? new DailyTotals { Date = day, Totals = new MacroTotals() });
         }
-        return list;
+        // remove empty days until the first one containing a meal
+        var trimmed = list
+            .SkipWhile(d =>
+                d.Totals.Calories == 0 &&
+                d.Totals.Proteins == 0 &&
+                d.Totals.Fats == 0 &&
+                d.Totals.Carbs == 0)
+            .ToList();
+        return trimmed;
     }
 }
 


### PR DESCRIPTION
## Summary
- skip leading days without meals in daily stats

## Testing
- `~/.dotnet/dotnet test FoodBot/FoodBot.sln`


------
https://chatgpt.com/codex/tasks/task_e_68af53bfd34883318d6fe32feb8459b5