### PR TITLE
Fix explicit identity insertion for PersonalCard entries

### DIFF
--- a/FoodBot/Data/BotDbContext.cs
+++ b/FoodBot/Data/BotDbContext.cs
@@ -28,5 +28,9 @@ public class BotDbContext : DbContext
 
         modelBuilder.Entity<PersonalCard>()
             .HasKey(x => x.ChatId);
+
+        modelBuilder.Entity<PersonalCard>()
+            .Property(x => x.ChatId)
+            .ValueGeneratedNever();
     }
 }

--- a/FoodBot/Data/PersonalCard.cs
+++ b/FoodBot/Data/PersonalCard.cs
@@ -1,10 +1,14 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace FoodBot.Data;
 
 public class PersonalCard
 {
-    [Key] public long ChatId { get; set; }
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public long ChatId { get; set; }
+
     [MaxLength(256)] public string? Email { get; set; }
     [MaxLength(256)] public string? Name { get; set; }
     public int? BirthYear { get; set; }


### PR DESCRIPTION
## Summary
- Prevent `ChatId` from being treated as an identity column in `PersonalCard`
- Configure EF Core to avoid value generation for `PersonalCard.ChatId`

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b002c5327c833197bfac3f7eae1827