### PR TITLE
Add diet analysis reports with OpenAI

### DIFF
--- a/FoodBot/Controllers/AnalysisController.cs
+++ b/FoodBot/Controllers/AnalysisController.cs
@@ -1,0 +1,34 @@
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using FoodBot.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FoodBot.Controllers;
+
+[ApiController]
+[Route("api/analysis")]
+[Authorize(AuthenticationSchemes = "Bearer")]
+public sealed class AnalysisController : ControllerBase
+{
+    private readonly DietAnalysisService _service;
+
+    public AnalysisController(DietAnalysisService service)
+    {
+        _service = service;
+    }
+
+    private long GetChatId() =>
+        long.TryParse(User.FindFirstValue("chat_id"), out var id) ? id : throw new UnauthorizedAccessException();
+
+    [HttpGet]
+    public async Task<IActionResult> Get(CancellationToken ct)
+    {
+        var chatId = GetChatId();
+        var report = await _service.GetOrGenerateAsync(chatId, ct);
+        if (report.IsProcessing)
+            return Accepted(new { status = "processing" });
+        return Ok(new { status = "ok", markdown = report.Markdown, createdAtUtc = report.CreatedAtUtc });
+    }
+}

--- a/FoodBot/Data/AnalysisReport.cs
+++ b/FoodBot/Data/AnalysisReport.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace FoodBot.Data;
+
+public class AnalysisReport
+{
+    [Key] public int Id { get; set; }
+
+    public long ChatId { get; set; }
+
+    public DateTime ReportDate { get; set; }
+
+    [Column(TypeName = "nvarchar(max)")] public string? Markdown { get; set; }
+
+    public bool IsProcessing { get; set; }
+
+    public DateTimeOffset CreatedAtUtc { get; set; }
+}

--- a/FoodBot/Data/BotDbContext.cs
+++ b/FoodBot/Data/BotDbContext.cs
@@ -11,6 +11,7 @@ public class BotDbContext : DbContext
 
     public DbSet<AppStartCode> StartCodes => Set<AppStartCode>();
     public DbSet<PersonalCard> PersonalCards => Set<PersonalCard>();
+    public DbSet<AnalysisReport> AnalysisReports => Set<AnalysisReport>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -32,5 +33,8 @@ public class BotDbContext : DbContext
         modelBuilder.Entity<PersonalCard>()
             .Property(x => x.ChatId)
             .ValueGeneratedNever();
+
+        modelBuilder.Entity<AnalysisReport>()
+            .HasIndex(x => new { x.ChatId, x.ReportDate });
     }
 }

--- a/FoodBot/Migrations/20250828081500_analysisreport.cs
+++ b/FoodBot/Migrations/20250828081500_analysisreport.cs
@@ -1,0 +1,44 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FoodBot.Migrations
+{
+    /// <inheritdoc />
+    public partial class analysisreport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AnalysisReports",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ChatId = table.Column<long>(type: "bigint", nullable: false),
+                    ReportDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Markdown = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    IsProcessing = table.Column<bool>(type: "bit", nullable: false),
+                    CreatedAtUtc = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AnalysisReports", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AnalysisReports_ChatId_ReportDate",
+                table: "AnalysisReports",
+                columns: new[] { "ChatId", "ReportDate" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AnalysisReports");
+        }
+    }
+}

--- a/FoodBot/Migrations/BotDbContextModelSnapshot.cs
+++ b/FoodBot/Migrations/BotDbContextModelSnapshot.cs
@@ -132,6 +132,36 @@ namespace FoodBot.Migrations
 
                     b.ToTable("Meals");
                 });
+
+            modelBuilder.Entity("FoodBot.Data.AnalysisReport", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<long>("ChatId")
+                        .HasColumnType("bigint");
+
+                    b.Property<DateTimeOffset>("CreatedAtUtc")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<bool>("IsProcessing")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Markdown")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<DateTime>("ReportDate")
+                        .HasColumnType("datetime2");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ChatId", "ReportDate");
+
+                    b.ToTable("AnalysisReports");
+                });
 #pragma warning restore 612, 618
         }
     }

--- a/FoodBot/Program.cs
+++ b/FoodBot/Program.cs
@@ -52,6 +52,7 @@ builder.Services.AddSingleton<SpeechToTextService>();
 builder.Services.AddScoped<TelegramReportService>();
 builder.Services.AddScoped<StatsService>();
 builder.Services.AddScoped<PersonalCardService>();
+builder.Services.AddScoped<DietAnalysisService>();
 
 // ===== Controllers / API =====
 builder.Services.AddControllers(); // AppAuthController / MealsController

--- a/FoodBot/Services/DietAnalysisService.cs
+++ b/FoodBot/Services/DietAnalysisService.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using FoodBot.Data;
+
+namespace FoodBot.Services;
+
+public sealed class DietAnalysisService
+{
+    private readonly BotDbContext _db;
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly string _apiKey;
+
+    public DietAnalysisService(BotDbContext db, IHttpClientFactory httpFactory, IConfiguration cfg)
+    {
+        _db = db;
+        _httpFactory = httpFactory;
+        _apiKey = cfg["OpenAI:ApiKey"] ?? throw new InvalidOperationException("OpenAI:ApiKey missing");
+    }
+
+    public async Task<AnalysisReport> GetOrGenerateAsync(long chatId, CancellationToken ct)
+    {
+        var today = DateTime.UtcNow.Date;
+        var existing = await _db.AnalysisReports
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.ChatId == chatId && r.ReportDate == today, ct);
+        if (existing != null)
+        {
+            if (!existing.IsProcessing)
+                return existing;
+            return existing; // still processing
+        }
+
+        var hasMealsToday = await _db.Meals
+            .AsNoTracking()
+            .AnyAsync(m => m.ChatId == chatId && m.CreatedAtUtc.Date == today, ct);
+        if (!hasMealsToday)
+        {
+            var last = await _db.AnalysisReports
+                .AsNoTracking()
+                .Where(r => r.ChatId == chatId && !r.IsProcessing)
+                .OrderByDescending(r => r.ReportDate)
+                .FirstOrDefaultAsync(ct);
+            if (last != null)
+                return last;
+        }
+
+        var rec = new AnalysisReport
+        {
+            ChatId = chatId,
+            ReportDate = today,
+            IsProcessing = true,
+            CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+        _db.AnalysisReports.Add(rec);
+        await _db.SaveChangesAsync(ct);
+
+        try
+        {
+            var markdown = await GenerateReportAsync(chatId, ct);
+            rec.Markdown = markdown;
+            rec.IsProcessing = false;
+            rec.CreatedAtUtc = DateTimeOffset.UtcNow;
+            await _db.SaveChangesAsync(ct);
+        }
+        catch
+        {
+            rec.IsProcessing = false;
+            await _db.SaveChangesAsync(ct);
+            throw;
+        }
+
+        return rec;
+    }
+
+    private async Task<string> GenerateReportAsync(long chatId, CancellationToken ct)
+    {
+        var card = await _db.PersonalCards.AsNoTracking().FirstOrDefaultAsync(x => x.ChatId == chatId, ct);
+        var from = DateTimeOffset.UtcNow.AddDays(-90);
+        var meals = await _db.Meals.AsNoTracking()
+            .Where(m => m.ChatId == chatId && m.CreatedAtUtc >= from)
+            .OrderBy(m => m.CreatedAtUtc)
+            .Select(m => new { m.DishName, m.CreatedAtUtc, m.CaloriesKcal, m.ProteinsG, m.FatsG, m.CarbsG })
+            .ToListAsync(ct);
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"Client info: birth year: {card?.BirthYear}, goals: {card?.DietGoals}, restrictions: {card?.MedicalRestrictions}.");
+        sb.AppendLine("Meal history (last 90 days):");
+        sb.AppendLine("| Time | Dish | Calories | Proteins | Fats | Carbs |");
+        sb.AppendLine("|---|---|---|---|---|---|");
+        foreach (var m in meals)
+        {
+            var time = m.CreatedAtUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm");
+            sb.AppendLine($"| {time} | {m.DishName} | {m.CaloriesKcal ?? 0} | {m.ProteinsG ?? 0} | {m.FatsG ?? 0} | {m.CarbsG ?? 0} |");
+        }
+        sb.AppendLine("Give dietologist recommendations for the rest of the day, week, month and quarter based on the goals and restrictions. Use markdown with tables.");
+
+        var reqObj = new
+        {
+            model = "o4-mini",
+            input = new object[]
+            {
+                new { role = "system", content = "You are a helpful dietologist." },
+                new { role = "user", content = sb.ToString() }
+            }
+        };
+        var body = JsonSerializer.Serialize(reqObj);
+        var http = _httpFactory.CreateClient();
+        using var msg = new HttpRequestMessage(HttpMethod.Post, "https://api.openai.com/v1/responses");
+        msg.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+        msg.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        using var resp = await http.SendAsync(msg, ct);
+        var respText = await resp.Content.ReadAsStringAsync(ct);
+        resp.EnsureSuccessStatusCode();
+        using var doc = JsonDocument.Parse(respText);
+        var content = doc.RootElement.GetProperty("output")[0]
+            .GetProperty("content")[0]
+            .GetProperty("text")
+            .GetProperty("value")
+            .GetString();
+        return content ?? string.Empty;
+    }
+}

--- a/mobile/calorie-counter/package-lock.json
+++ b/mobile/calorie-counter/package-lock.json
@@ -29,6 +29,7 @@
         "@fontsource/material-icons-outlined": "^5.2.6",
         "@fontsource/material-icons-round": "^5.2.6",
         "@fontsource/material-icons-sharp": "^5.2.6",
+        "marked": "^12.0.2",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -10919,6 +10920,18 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/mobile/calorie-counter/package.json
+++ b/mobile/calorie-counter/package.json
@@ -33,7 +33,8 @@
     "@fontsource/material-icons-sharp": "^5.2.6",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.15.0",
+    "marked": "^12.0.2"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^19.0.6",

--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.html
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.html
@@ -1,32 +1,7 @@
-﻿<mat-card>
-  <h3>Итог на сегодня</h3>
-  <ng-container *ngIf="a.todayRecommendation() as t">
-    <p><b>Съедено:</b> {{ t.consumed.calories | number:'1.0-0' }} ккал · Б {{ t.consumed.proteins | number:'1.0-0' }} · Ж {{ t.consumed.fats | number:'1.0-0' }} · У {{ t.consumed.carbs | number:'1.0-0' }}</p>
-    <p><b>Осталось:</b> {{ t.remaining.calories | number:'1.0-0' }} ккал · Б {{ t.remaining.proteins | number:'1.0-0' }} · Ж {{ t.remaining.fats | number:'1.0-0' }} · У {{ t.remaining.carbs | number:'1.0-0' }}</p>
-    <mat-chip-listbox>
-      <mat-chip>{{ t.tip }}</mat-chip>
-    </mat-chip-listbox>
-  </ng-container>
+<mat-card *ngIf="a.loading">Загрузка отчёта...</mat-card>
+<mat-card *ngIf="!a.loading && a.report?.status === 'processing'">
+  <p>Отчёт формируется, попробуйте позже.</p>
 </mat-card>
-
-<mat-card>
-  <h3>Периоды</h3>
-  <div class="periods">
-    <div class="period" *ngFor="let d of [7,30,90]">
-      <h4 *ngIf="d===7">Неделя</h4>
-      <h4 *ngIf="d===30">Месяц (30 дней)</h4>
-      <h4 *ngIf="d===90">Квартал (90 дней)</h4>
-      <ng-container *ngIf="a.periodSummary(d) as s">
-        <p><b>Записей:</b> {{ s.entries }}, дней: {{ s.days }}</p>
-        <p><b>Итого:</b> {{ s.totals.calories | number:'1.0-0' }} ккал</p>
-        <p><b>Среднесуточно:</b> {{ s.avgDaily.calories | number:'1.0-0' }} ккал · Б {{ s.avgDaily.proteins | number:'1.0-0' }} · Ж {{ s.avgDaily.fats | number:'1.0-0' }} · У {{ s.avgDaily.carbs | number:'1.0-0' }}</p>
-        <p><i>{{ s.recommendation }}</i></p>
-      </ng-container>
-    </div>
-  </div>
+<mat-card *ngIf="!a.loading && a.report?.status === 'ok'">
+  <div [innerHTML]="a.report?.markdown | markdown"></div>
 </mat-card>
-
-<style>
-.periods { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
-.period { border: 1px dashed rgba(0,0,0,.2); padding: 8px; border-radius: 8px; }
-</style>

--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.ts
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.ts
@@ -1,13 +1,13 @@
 ﻿import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
-import { MatChipsModule } from '@angular/material/chips';
 import { AnalysisService } from '../../services/analysis.service';
+import { MarkdownPipe } from '../../pipes/markdown.pipe';
 
 @Component({
   selector: 'app-analysis',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatChipsModule],
+  imports: [CommonModule, MatCardModule, MarkdownPipe],
   templateUrl: './analysis.page.html',
   styleUrls: ['./analysis.page.scss']
 })

--- a/mobile/calorie-counter/src/app/pipes/markdown.pipe.ts
+++ b/mobile/calorie-counter/src/app/pipes/markdown.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { marked } from 'marked';
+
+@Pipe({
+  name: 'markdown',
+  standalone: true
+})
+export class MarkdownPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(value: string | null | undefined): SafeHtml {
+    const html = marked.parse(value || '') as string;
+    return this.sanitizer.bypassSecurityTrustHtml(html);
+  }
+}

--- a/mobile/calorie-counter/src/app/services/analysis.service.ts
+++ b/mobile/calorie-counter/src/app/services/analysis.service.ts
@@ -1,63 +1,31 @@
-﻿import { Injectable } from '@angular/core';
-import { MealService } from './meal.service';
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 
-export interface Goals { calories: number; proteins: number; fats: number; carbs: number; }
-
-const DEFAULT_GOALS: Goals = { calories: 2000, proteins: 100, fats: 70, carbs: 250 };
+export interface AnalysisResponse {
+  status: string;
+  markdown?: string;
+  createdAtUtc?: string;
+}
 
 @Injectable({ providedIn: 'root' })
 export class AnalysisService {
-  goals: Goals = { ...DEFAULT_GOALS };
+  report?: AnalysisResponse;
+  loading = false;
 
-  constructor(private meals: MealService) {}
+  constructor(private http: HttpClient) {
+    this.refresh();
+  }
 
-  todayRecommendation() {
-    const today = this.meals.sumForDate(new Date());
-    const g = this.goals;
-    return {
-      consumed: today.totals,
-      remaining: {
-        calories: Math.max(0, g.calories - today.totals.calories),
-        proteins: Math.max(0, g.proteins - today.totals.proteins),
-        fats: Math.max(0, g.fats - today.totals.fats),
-        carbs: Math.max(0, g.carbs - today.totals.carbs)
+  refresh() {
+    this.loading = true;
+    this.http.get<AnalysisResponse>('/api/analysis').subscribe({
+      next: r => {
+        this.report = r;
+        this.loading = false;
       },
-      tip: this.tipForRemainder(g, today.totals)
-    };
-  }
-
-  periodSummary(days: number) {
-    const { totals, count } = this.meals.sumDaysBack(days);
-    const avgDaily = {
-      calories: totals.calories / days,
-      proteins: totals.proteins / days,
-      fats: totals.fats / days,
-      carbs: totals.carbs / days
-    };
-    return {
-      totals, days, entries: count, avgDaily,
-      deviationFromGoals: {
-        calories: avgDaily.calories - this.goals.calories,
-        proteins: avgDaily.proteins - this.goals.proteins,
-        fats: avgDaily.fats - this.goals.fats,
-        carbs: avgDaily.carbs - this.goals.carbs
-      },
-      recommendation: this.recommendForPeriod(avgDaily)
-    };
-  }
-
-  private tipForRemainder(goals: Goals, tot: any) {
-    const remainCal = goals.calories - tot.calories;
-    if (remainCal > 400) return 'До конца дня: сделай плотный приём пищи 400–700 ккал (белок 25–40 г).';
-    if (remainCal > 150) return 'Подойдёт перекус 150–300 ккал, с акцентом на белок.';
-    if (remainCal > 0)   return 'Финишируй лёгким перекусом до 150 ккал.';
-    return 'Лимит на сегодня достигнут — держи воду/чай, без лишних калорий.';
-  }
-
-  private recommendForPeriod(avg: any) {
-    const over = avg.calories - this.goals.calories;
-    if (over > 150)   return 'В среднем переедание. Уменьши 200–300 ккал/день; добавь овощи и белок.';
-    if (over < -150)  return 'В среднем недобор. Добавь 150–250 ккал/день, держи белок ≥ 100 г.';
-    return 'Баланс около цели. Продолжай в том же духе; следи за белком и клетчаткой.';
+      error: _ => {
+        this.loading = false;
+      }
+    });
   }
 }


### PR DESCRIPTION
## Summary
- store generated diet analysis in new `AnalysisReport` table and expose it via secured `/api/analysis`
- generate diet recommendations using OpenAI reasoning model with meal history and personal card
- render analysis report on mobile client with markdown support

## Testing
- `npm run build`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b00efd44f883319b4076732c7d38f7