### PR TITLE
Split diet analysis by time period

### DIFF
--- a/FoodBot/Controllers/AnalysisController.cs
+++ b/FoodBot/Controllers/AnalysisController.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using FoodBot.Models;
 using FoodBot.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -22,13 +23,23 @@ public sealed class AnalysisController : ControllerBase
     private long GetChatId() =>
         long.TryParse(User.FindFirstValue("chat_id"), out var id) ? id : throw new UnauthorizedAccessException();
 
-    [HttpGet]
-    public async Task<IActionResult> Get(CancellationToken ct)
+    [HttpGet("day")]
+    public async Task<IActionResult> GetDay(CancellationToken ct)
     {
         var chatId = GetChatId();
-        var report = await _service.GetOrGenerateAsync(chatId, ct);
+        var report = await _service.GetDailyAsync(chatId, ct);
         if (report.IsProcessing)
             return Accepted(new { status = "processing" });
         return Ok(new { status = "ok", markdown = report.Markdown, createdAtUtc = report.CreatedAtUtc });
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Get([FromQuery] AnalysisPeriod period, CancellationToken ct)
+    {
+        if (period == AnalysisPeriod.Day)
+            return BadRequest("Use /api/analysis/day for day recommendations");
+        var chatId = GetChatId();
+        var markdown = await _service.GetPlanAsync(chatId, period, ct);
+        return Ok(new { status = "ok", markdown, period = period.ToString().ToLower() });
     }
 }

--- a/FoodBot/Models/AnalysisPeriod.cs
+++ b/FoodBot/Models/AnalysisPeriod.cs
@@ -1,0 +1,9 @@
+namespace FoodBot.Models;
+
+public enum AnalysisPeriod
+{
+    Day,
+    Week,
+    Month,
+    Quarter
+}


### PR DESCRIPTION
## Summary
- add `AnalysisPeriod` enum for day/week/month/quarter
- update diet analysis service to generate recommendations by period with separate OpenAI prompts
- expose `/api/analysis/day` and `/api/analysis?period=` endpoints

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0161e9f5c8331be9e82fd996eb8e2