### PR TITLE
feat: improve analysis refresh handling

### DIFF
--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.html
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.html
@@ -1,7 +1,9 @@
 <mat-card *ngIf="a.loading">Загрузка отчёта...</mat-card>
 <mat-card *ngIf="!a.loading && a.report?.status === 'processing'">
   <p>Отчёт формируется, попробуйте позже.</p>
+  <button mat-raised-button color="primary" (click)="a.refresh()">Обновить</button>
 </mat-card>
 <mat-card *ngIf="!a.loading && a.report?.status === 'ok'">
+  <button mat-raised-button color="primary" (click)="a.refresh()">Обновить</button>
   <div [innerHTML]="a.report?.markdown | markdown"></div>
 </mat-card>

--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.ts
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.ts
@@ -1,16 +1,25 @@
-﻿import { Component } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
 import { AnalysisService } from '../../services/analysis.service';
 import { MarkdownPipe } from '../../pipes/markdown.pipe';
 
 @Component({
   selector: 'app-analysis',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MarkdownPipe],
+  imports: [CommonModule, MatCardModule, MatButtonModule, MarkdownPipe],
   templateUrl: './analysis.page.html',
   styleUrls: ['./analysis.page.scss']
 })
-export class AnalysisPage {
+export class AnalysisPage implements OnInit, OnDestroy {
   constructor(public a: AnalysisService) {}
+
+  ngOnInit() {
+    this.a.refresh();
+  }
+
+  ngOnDestroy() {
+    this.a.cancel();
+  }
 }

--- a/mobile/calorie-counter/src/app/services/analysis.service.ts
+++ b/mobile/calorie-counter/src/app/services/analysis.service.ts
@@ -11,21 +11,35 @@ export interface AnalysisResponse {
 export class AnalysisService {
   report?: AnalysisResponse;
   loading = false;
+  private timer?: any;
 
-  constructor(private http: HttpClient) {
-    this.refresh();
-  }
+  constructor(private http: HttpClient) {}
 
   refresh() {
+    if (this.loading) return;
     this.loading = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
     this.http.get<AnalysisResponse>('/api/analysis').subscribe({
       next: r => {
         this.report = r;
         this.loading = false;
+        if (r.status === 'processing') {
+          this.timer = setTimeout(() => this.refresh(), 5000);
+        }
       },
       error: _ => {
         this.loading = false;
       }
     });
+  }
+
+  cancel() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add auto-refresh logic for analysis report polling
- expose refresh button and lifecycle hooks for analysis page

## Testing
- `npm test` *(fails: src/app/app.component.spec.ts:8:7 - error TS1136: Property assignment expected)*

------
https://chatgpt.com/codex/tasks/task_e_68b018052f50833193674da949092fa0