### PR TITLE
Handle day period in analysis endpoint

### DIFF
--- a/FoodBot/Controllers/AnalysisController.cs
+++ b/FoodBot/Controllers/AnalysisController.cs
@@ -36,9 +36,15 @@ public sealed class AnalysisController : ControllerBase
     [HttpGet]
     public async Task<IActionResult> Get([FromQuery] AnalysisPeriod period, CancellationToken ct)
     {
-        if (period == AnalysisPeriod.Day)
-            return BadRequest("Use /api/analysis/day for day recommendations");
         var chatId = GetChatId();
+        if (period == AnalysisPeriod.Day)
+        {
+            var report = await _service.GetDailyAsync(chatId, ct);
+            if (report.IsProcessing)
+                return Accepted(new { status = "processing" });
+            return Ok(new { status = "ok", markdown = report.Markdown, createdAtUtc = report.CreatedAtUtc });
+        }
+
         var markdown = await _service.GetPlanAsync(chatId, period, ct);
         return Ok(new { status = "ok", markdown, period = period.ToString().ToLower() });
     }


### PR DESCRIPTION
## Summary
- Support day period in `/api/analysis` endpoint by returning daily analysis instead of a 400 error

## Testing
- `~/.dotnet/dotnet build FoodBot/FoodBot.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68b01fbf2e8083318c56627c4d93ac24