### PR TITLE
Fix OpenAI model name for diet analysis and nutrition

### DIFF
--- a/FoodBot/Services/DietAnalysisService.cs
+++ b/FoodBot/Services/DietAnalysisService.cs
@@ -131,7 +131,7 @@ public sealed class DietAnalysisService
 
         var reqObj = new
         {
-            model = "o4-mini",
+            model = "gpt-4o-mini",
             input = new object[]
             {
                 new { role = "system", content = "You are a helpful dietologist." },

--- a/FoodBot/Services/NutritionService.cs
+++ b/FoodBot/Services/NutritionService.cs
@@ -52,7 +52,7 @@ namespace FoodBot.Services
 
             // Модели оставляем в конфиге (не секретные параметры)
             _visionModel = cfg["OpenAI:Model"] ?? "gpt-4o-mini";
-            _reasoningModel = cfg["OpenAI:ReasoningModel"] ?? "o4-mini";
+            _reasoningModel = cfg["OpenAI:ReasoningModel"] ?? "gpt-4o-mini";
 
             var foodsPath = cfg["Foods:Path"];
             if (string.IsNullOrWhiteSpace(foodsPath))


### PR DESCRIPTION
## Summary
- use `gpt-4o-mini` model in diet analysis report generation to avoid API bad request
- default to `gpt-4o-mini` reasoning model for nutrition service

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0356518ec8331a8a172bcc61e403a