### PR TITLE
fix: replace invalid input_json

### DIFF
--- a/FoodBot/Services/DietAnalysisService.cs
+++ b/FoodBot/Services/DietAnalysisService.cs
@@ -141,7 +141,9 @@ public sealed class DietAnalysisService
                     content = new object[]
                     {
                         new { type = "input_text", text = prompt },
-                        new { type = "input_json", json = data }
+                        // OpenAI responses API does not support an "input_json" type.
+                        // Serialize the structured data and send it as plain text instead.
+                        new { type = "input_text", text = JsonSerializer.Serialize(data) }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- replace unsupported `input_json` with serialized text in `DietAnalysisService`

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b03b3a825083318dfe2b04bd7ffd69