### PR TITLE
feat: refresh daily analysis and add period tabs

### DIFF
--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.html
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.html
@@ -1,9 +1,16 @@
+<mat-tab-group (selectedIndexChange)="changePeriod($event)">
+  <mat-tab label="День"></mat-tab>
+  <mat-tab label="Неделя"></mat-tab>
+  <mat-tab label="Месяц"></mat-tab>
+  <mat-tab label="Квартал"></mat-tab>
+</mat-tab-group>
+
 <mat-card *ngIf="a.loading">Загрузка отчёта...</mat-card>
-<mat-card *ngIf="!a.loading && a.report?.status === 'processing'">
-  <p>Отчёт формируется, попробуйте позже.</p>
-  <button mat-raised-button color="primary" (click)="a.refresh()">Обновить</button>
-</mat-card>
-<mat-card *ngIf="!a.loading && a.report?.status === 'ok'">
-  <button mat-raised-button color="primary" (click)="a.refresh()">Обновить</button>
-  <div [innerHTML]="a.report?.markdown | markdown"></div>
-</mat-card>
+  <mat-card *ngIf="!a.loading && a.report?.status === 'processing'">
+    <p>Отчёт формируется, попробуйте позже.</p>
+    <button mat-raised-button color="primary" (click)="a.refresh(period)">Обновить</button>
+  </mat-card>
+  <mat-card *ngIf="!a.loading && a.report?.status === 'ok'">
+    <button mat-raised-button color="primary" (click)="a.refresh(period)">Обновить</button>
+    <div [innerHTML]="a.report?.markdown | markdown"></div>
+  </mat-card>

--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.ts
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.ts
@@ -2,24 +2,33 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
-import { AnalysisService } from '../../services/analysis.service';
+import { MatTabsModule } from '@angular/material/tabs';
+import { AnalysisService, AnalysisPeriod } from '../../services/analysis.service';
 import { MarkdownPipe } from '../../pipes/markdown.pipe';
 
 @Component({
   selector: 'app-analysis',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatButtonModule, MarkdownPipe],
+  imports: [CommonModule, MatCardModule, MatButtonModule, MatTabsModule, MarkdownPipe],
   templateUrl: './analysis.page.html',
   styleUrls: ['./analysis.page.scss']
 })
 export class AnalysisPage implements OnInit, OnDestroy {
+  period: AnalysisPeriod = 'day';
+
   constructor(public a: AnalysisService) {}
 
   ngOnInit() {
-    this.a.refresh();
+    this.a.refresh(this.period);
   }
 
   ngOnDestroy() {
     this.a.cancel();
+  }
+
+  changePeriod(index: number) {
+    const map: AnalysisPeriod[] = ['day', 'week', 'month', 'quarter'];
+    this.period = map[index] ?? 'day';
+    this.a.refresh(this.period);
   }
 }

--- a/mobile/calorie-counter/src/app/services/analysis.service.ts
+++ b/mobile/calorie-counter/src/app/services/analysis.service.ts
@@ -8,6 +8,8 @@ export interface AnalysisResponse {
   createdAtUtc?: string;
 }
 
+export type AnalysisPeriod = 'day' | 'week' | 'month' | 'quarter';
+
 @Injectable({ providedIn: 'root' })
 export class AnalysisService {
   report?: AnalysisResponse;
@@ -18,19 +20,20 @@ export class AnalysisService {
 
   private get baseUrl(): string { return this.auth.apiBaseUrl; }
 
-  refresh() {
+  refresh(period: AnalysisPeriod = 'day') {
     if (this.loading) return;
     this.loading = true;
+    this.report = undefined;
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = undefined;
     }
-    this.http.get<AnalysisResponse>(`${this.baseUrl}/api/analysis`).subscribe({
+    this.http.get<AnalysisResponse>(`${this.baseUrl}/api/analysis?period=${period}`).subscribe({
       next: r => {
         this.report = r;
         this.loading = false;
-        if (r.status === 'processing') {
-          this.timer = setTimeout(() => this.refresh(), 5000);
+        if (period === 'day' && r.status === 'processing') {
+          this.timer = setTimeout(() => this.refresh(period), 5000);
         }
       },
       error: _ => {


### PR DESCRIPTION
## Summary
- regenerate daily analysis when new meals appear
- add period tabs in Angular client for day, week, month, and quarter

## Testing
- `dotnet build FoodBot/FoodBot.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b068900a9c83319b372ab5a0ac1138