### PR TITLE
Fix history detail dialog height

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
@@ -14,7 +14,7 @@
   padding-right: 6px;
 }
 
-.container { display: flex; flex-direction: column; gap: 1x; height: 100%; overflow: auto; padding: 12px; }
+.container { display: flex; flex-direction: column; gap: 1x; max-height: 100%; overflow: auto; padding: 12px; }
 .photo { width: 100%; height: auto; max-height: 55vh; border-radius: 6px; object-fit: contain; }
 .macros { font-size: 13px; line-height: 1.2; }
 .ingredients { font-size: 12.5px; line-height: 1.2; }


### PR DESCRIPTION
## Summary
- adjust history detail dialog container to use max-height, allowing dialog to shrink when content is short

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b1530efc688331800c29a40e44d98b