### PR TITLE
Add date separators to history page

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history.page.html
+++ b/mobile/calorie-counter/src/app/pages/history/history.page.html
@@ -5,22 +5,25 @@
   [infiniteScrollThrottle]="200"
   (scrolled)="onScrollDown()"
 >
-  <mat-card *ngFor="let m of items" class="meal-card" (click)="openDialog(m)">
-    <div class="row">
-      <img *ngIf="m.hasImage && imgUrl(m.id)" [src]="imgUrl(m.id)" alt="meal" />
-      <div class="info">
-        <div class="time">{{ time(m.createdAtUtc) }}</div>
-        <div class="kcal">
-          {{ m.caloriesKcal ?? "—" }} ккал
-          <span class="dish" *ngIf="m.dishName">· {{ m.dishName }}</span>
+  <ng-container *ngFor="let m of items; let i = index">
+    <div class="date" *ngIf="showDateSeparator(i)">{{ date(m.createdAtUtc) }}</div>
+    <mat-card class="meal-card" (click)="openDialog(m)">
+      <div class="row">
+        <img *ngIf="m.hasImage && imgUrl(m.id)" [src]="imgUrl(m.id)" alt="meal" />
+        <div class="info">
+          <div class="time">{{ time(m.createdAtUtc) }}</div>
+          <div class="kcal">
+            {{ m.caloriesKcal ?? "—" }} ккал
+            <span class="dish" *ngIf="m.dishName">· {{ m.dishName }}</span>
+          </div>
+          <div class="macros">
+            Б {{ m.proteinsG ?? "—" }} · Ж {{ m.fatsG ?? "—" }} · У {{ m.carbsG ?? "—" }} · {{ m.weightG ?? "—" }} г
+          </div>
+          <div class="ing" *ngIf="m.ingredients?.length">Ингредиенты: {{ m.ingredients.join(", ") }}</div>
         </div>
-        <div class="macros">
-          Б {{ m.proteinsG ?? "—" }} · Ж {{ m.fatsG ?? "—" }} · У {{ m.carbsG ?? "—" }} · {{ m.weightG ?? "—" }} г
-        </div>
-        <div class="ing" *ngIf="m.ingredients?.length">Ингредиенты: {{ m.ingredients.join(", ") }}</div>
       </div>
-    </div>
-  </mat-card>
+    </mat-card>
+  </ng-container>
 
   <mat-spinner *ngIf="loading"></mat-spinner>
 </div>
@@ -34,5 +37,6 @@ img { width: 96px; height: 96px; object-fit: cover; border-radius: 8px; }
 .kcal { font-weight: 600; margin: 4px 0; }
 .dish { opacity: .8; margin-left: 6px; }
 .macros { font-size: 13px; }
+.date { font-weight: 600; margin: 16px 0 8px; }
 </style>
 

--- a/mobile/calorie-counter/src/app/pages/history/history.page.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history.page.ts
@@ -72,6 +72,20 @@ export class HistoryPage implements OnInit, OnDestroy {
   time(s: string) { return new Date(s).toLocaleString(); }
   imgUrl(id: number) { return this.imageUrls.get(id) || ""; }
 
+  date(s: string) { return new Date(s).toLocaleDateString(); }
+
+  private sameDay(a: string, b: string) {
+    const da = new Date(a); const db = new Date(b);
+    return da.getFullYear() === db.getFullYear() &&
+           da.getMonth() === db.getMonth() &&
+           da.getDate() === db.getDate();
+  }
+
+  showDateSeparator(i: number) {
+    if (i === 0) return true;
+    return !this.sameDay(this.items[i - 1].createdAtUtc, this.items[i].createdAtUtc);
+  }
+
   openDialog(item: MealListItem) {
     this.dialog.open(HistoryDetailDialogComponent, {
       data: { item, imageUrl: this.imgUrl(item.id) },


### PR DESCRIPTION
## Summary
- show date separators between meals on History page
- add helper functions for date formatting and separator logic

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b16dd22e988331805464e8e7962e42