### PR TITLE
feat: allow deleting meals from history

### DIFF
--- a/FoodBot/Controllers/MealsApiController.cs
+++ b/FoodBot/Controllers/MealsApiController.cs
@@ -302,5 +302,19 @@ namespace FoodBot.Controllers
             stream.Position = 0;
             return File(stream, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", filename);
         }
+
+        // ---------- Удаление блюда ----------
+        // DELETE /api/meals/{id}
+        [HttpDelete("{id:int}")]
+        public async Task<IActionResult> Delete([FromRoute] int id, CancellationToken ct)
+        {
+            var chatId = GetChatId();
+            var m = await _db.Meals.Where(x => x.ChatId == chatId && x.Id == id).FirstOrDefaultAsync(ct);
+            if (m == null) return NotFound();
+
+            _db.Meals.Remove(m);
+            await _db.SaveChangesAsync(ct);
+            return NoContent();
+        }
     }
 }

--- a/mobile/calorie-counter/src/app/pages/history/history-clarify.dialog.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history-clarify.dialog.ts
@@ -36,6 +36,7 @@ import { VoiceService } from '../../services/voice.service';
       </button>
     </div>
     <div mat-dialog-actions align="end">
+      <button mat-button color="warn" (click)="remove()">Удалить</button>
       <button mat-button (click)="dialogRef.close()">Отмена</button>
       <button mat-raised-button color="primary" (click)="send()" [disabled]="!note.trim()">Отправить</button>
     </div>
@@ -76,6 +77,16 @@ export class HistoryClarifyDialogComponent {
       next: (r: ClarifyResult) => this.dialogRef.close(r),
       error: () => {
         this.snack.open('Ошибка уточнения', 'OK', { duration: 1500 });
+      }
+    });
+  }
+
+  remove() {
+    if (!confirm('Удалить запись?')) return;
+    this.api.deleteMeal(this.data.mealId).subscribe({
+      next: () => this.dialogRef.close({ deleted: true }),
+      error: () => {
+        this.snack.open('Не удалось удалить', 'OK', { duration: 1500 });
       }
     });
   }

--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
@@ -54,16 +54,22 @@ export class HistoryDetailDialogComponent implements OnInit {
 
   openClarify() {
     const ref = this.dialog.open(HistoryClarifyDialogComponent, { data: { mealId: this.data.item.id } });
-    ref.afterClosed().subscribe((r: ClarifyResult | undefined) => {
+    ref.afterClosed().subscribe((r: ClarifyResult | { deleted: true } | undefined) => {
       if (!r) return;
-      this.data.item.dishName = r.result.dish;
-      this.data.item.caloriesKcal = r.result.calories_kcal;
-      this.data.item.proteinsG = r.result.proteins_g;
-      this.data.item.fatsG = r.result.fats_g;
-      this.data.item.carbsG = r.result.carbs_g;
-      this.data.item.weightG = r.result.weight_g;
-      this.data.item.ingredients = r.result.ingredients;
-      this.data.item.products = r.products;
+      if ((r as any).deleted) {
+        this.snack.open('Запись удалена', 'OK', { duration: 1500 });
+        this.dialogRef.close({ deleted: true });
+        return;
+      }
+      const res = r as ClarifyResult;
+      this.data.item.dishName = res.result.dish;
+      this.data.item.caloriesKcal = res.result.calories_kcal;
+      this.data.item.proteinsG = res.result.proteins_g;
+      this.data.item.fatsG = res.result.fats_g;
+      this.data.item.carbsG = res.result.carbs_g;
+      this.data.item.weightG = res.result.weight_g;
+      this.data.item.ingredients = res.result.ingredients;
+      this.data.item.products = res.products;
       this.snack.open('Уточнение применено', 'OK', { duration: 1500 });
       this.dialogRef.close();
     });

--- a/mobile/calorie-counter/src/app/pages/history/history.page.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history.page.ts
@@ -104,12 +104,20 @@ export class HistoryPage implements OnInit, OnDestroy {
   }
 
   openDialog(item: MealListItem) {
-    this.dialog.open(HistoryDetailDialogComponent, {
+    const ref = this.dialog.open(HistoryDetailDialogComponent, {
       data: { item, imageUrl: this.imgUrl(item.id) },
       maxWidth: "100vw",
       maxHeight: "100vh",
       width: "95vw",
       height: "95vh"
+    });
+    ref.afterClosed().subscribe(r => {
+      if (r?.deleted) {
+        this.items = this.items.filter(x => x.id !== item.id);
+        this.total = Math.max(0, this.total - 1);
+        this.recomputeDateTotals();
+        this.loadMore();
+      }
     });
   }
 

--- a/mobile/calorie-counter/src/app/services/foodbot-api.service.ts
+++ b/mobile/calorie-counter/src/app/services/foodbot-api.service.ts
@@ -23,6 +23,9 @@ export class FoodbotApiService {
   getMeal(id: number): Observable<MealDetails> {
     return this.http.get<MealDetails>(`${this.baseUrl}/api/meals/${id}`);
   }
+  deleteMeal(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/api/meals/${id}`);
+  }
   getMealImageBlob(id: number): Observable<Blob> {
     return this.http.get(`${this.baseUrl}/api/meals/${id}/image`, { responseType: "blob" as const });
   }


### PR DESCRIPTION
## Summary
- add delete button with confirmation to history clarification dialog
- refresh history list after meal deletion
- backend API endpoint for deleting meals

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b178dc8528833196ae9026de4de2a5