### PR TITLE
feat(history): allow deleting meal from details

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.html
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.html
@@ -74,6 +74,7 @@
 
   <div class="buttons">
     <button mat-raised-button color="primary" (click)="openClarify()">Уточнить</button>
+    <button mat-button color="warn" (click)="remove()">Удалить</button>
     <button mat-button (click)="dialogRef.close()">Закрыть</button>
   </div>
 </div>

--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
@@ -74,4 +74,17 @@ export class HistoryDetailDialogComponent implements OnInit {
       this.dialogRef.close();
     });
   }
+
+  remove() {
+    if (!confirm('Удалить запись?')) return;
+    this.api.deleteMeal(this.data.item.id).subscribe({
+      next: () => {
+        this.snack.open('Запись удалена', 'OK', { duration: 1500 });
+        this.dialogRef.close({ deleted: true });
+      },
+      error: () => {
+        this.snack.open('Не удалось удалить', 'OK', { duration: 1500 });
+      }
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- add delete button with confirmation in meal history detail dialog
- wire dialog to existing delete API and update the list after removal

## Testing
- `npm test --silent -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b17b5f0a488331b4254b1984f637aa