### PR TITLE
fix: include current day in stats request

### DIFF
--- a/mobile/calorie-counter/src/app/services/stats.service.ts
+++ b/mobile/calorie-counter/src/app/services/stats.service.ts
@@ -33,8 +33,13 @@ export class StatsService {
 
   getDaily(from: Date, to: Date): Observable<DayStats[]> {
     const params = new HttpParams()
-      .set('from', from.toISOString().split('T')[0])
-      .set('to', to.toISOString().split('T')[0]);
+      .set('from', this.formatDate(from))
+      .set('to', this.formatDate(to));
     return this.http.get<DayStats[]>(`${this.baseUrl}/api/stats/daily`, { params });
+  }
+
+  private formatDate(d: Date): string {
+    const shifted = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+    return shifted.toISOString().split('T')[0];
   }
 }


### PR DESCRIPTION
## Summary
- send dates in local timezone when requesting daily stats so current day is included

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform.)*

------
https://chatgpt.com/codex/tasks/task_e_68b28449365c8331b46a6a6e3a0319e8