### PR TITLE
Move toolbar actions into sidenav drawer

### DIFF
--- a/mobile/calorie-counter/src/app/app.component.html
+++ b/mobile/calorie-counter/src/app/app.component.html
@@ -1,19 +1,17 @@
-﻿<mat-toolbar color="primary" class="topbar">
-  <span>Calorie Counter</span>
-  <span class="spacer"></span>
-  <a mat-icon-button aria-label="История" routerLink="/history"><mat-icon>history</mat-icon></a>
-  <a mat-icon-button aria-label="Добавить" routerLink="/add"><mat-icon>add_a_photo</mat-icon></a>
-  <a mat-icon-button aria-label="Анализ" routerLink="/analysis"><mat-icon>analytics</mat-icon></a>
-  <a mat-icon-button aria-label="Статистика" routerLink="/stats"><mat-icon>bar_chart</mat-icon></a>
-  <a mat-icon-button aria-label="Профиль" routerLink="/profile"><mat-icon>person</mat-icon></a>
-</mat-toolbar>
+<mat-sidenav-container class="app-shell">
+  <mat-sidenav #drawer mode="over" class="app-drawer" fixedInViewport>
+    <app-side-menu (close)="drawer.close()"></app-side-menu>
+  </mat-sidenav>
 
-<div class="container">
-  <router-outlet></router-outlet>
-</div>
-
-<style>
-.topbar { position: sticky; top: 0; z-index: 10; }
-.container { padding: 12px; }
-.spacer { flex: 1 1 auto; }
-</style>
+  <mat-sidenav-content class="app-content">
+    <mat-toolbar color="primary" class="topbar">
+      <button mat-icon-button (click)="drawer.toggle()">
+        <mat-icon>menu</mat-icon>
+      </button>
+      <span>Calorie Counter</span>
+    </mat-toolbar>
+    <div class="container">
+      <router-outlet></router-outlet>
+    </div>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/mobile/calorie-counter/src/app/app.component.scss
+++ b/mobile/calorie-counter/src/app/app.component.scss
@@ -1,0 +1,27 @@
+:host {
+  display: block;
+}
+
+.app-shell {
+  position: relative;
+}
+
+.app-drawer {
+  width: 260px;
+  z-index: 1000;
+}
+
+.app-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.container {
+  padding: 12px;
+}

--- a/mobile/calorie-counter/src/app/app.component.ts
+++ b/mobile/calorie-counter/src/app/app.component.ts
@@ -1,15 +1,30 @@
-﻿import { Component } from "@angular/core";
-import { RouterOutlet, RouterLink } from "@angular/router";
+import { Component, ViewChild } from "@angular/core";
+import { RouterOutlet, Router, NavigationEnd } from "@angular/router";
+import { filter } from 'rxjs/operators';
 import { MatToolbarModule } from "@angular/material/toolbar";
 import { MatIconModule } from "@angular/material/icon";
 import { MatButtonModule } from "@angular/material/button";
+import { MatSidenavModule, MatSidenav } from "@angular/material/sidenav";
+import { SideMenuComponent } from "./components/side-menu/side-menu.component";
 
 @Component({
   selector: "app-root",
   standalone: true,
-  imports: [RouterOutlet, RouterLink, MatToolbarModule, MatIconModule, MatButtonModule],
-  templateUrl: "./app.component.html"
+  imports: [RouterOutlet, MatToolbarModule, MatIconModule, MatButtonModule, MatSidenavModule, SideMenuComponent],
+  templateUrl: "./app.component.html",
+  styleUrls: ["./app.component.scss"],
 })
 export class AppComponent {
   title = 'calorie-counter';
+  @ViewChild('drawer') drawer!: MatSidenav;
+
+  constructor(private router: Router) {
+    this.router.events
+      .pipe(filter(e => e instanceof NavigationEnd))
+      .subscribe(() => {
+        if (this.drawer?.opened) {
+          this.drawer.close();
+        }
+      });
+  }
 }

--- a/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.html
+++ b/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.html
@@ -1,0 +1,22 @@
+<mat-nav-list>
+  <a mat-list-item routerLink="/history" (click)="close.emit()">
+    <mat-icon>history</mat-icon>
+    <span>История</span>
+  </a>
+  <a mat-list-item routerLink="/add" (click)="close.emit()">
+    <mat-icon>add_a_photo</mat-icon>
+    <span>Добавить</span>
+  </a>
+  <a mat-list-item routerLink="/analysis" (click)="close.emit()">
+    <mat-icon>analytics</mat-icon>
+    <span>Анализ</span>
+  </a>
+  <a mat-list-item routerLink="/stats" (click)="close.emit()">
+    <mat-icon>bar_chart</mat-icon>
+    <span>Статистика</span>
+  </a>
+  <a mat-list-item routerLink="/profile" (click)="close.emit()">
+    <mat-icon>person</mat-icon>
+    <span>Профиль</span>
+  </a>
+</mat-nav-list>

--- a/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.ts
+++ b/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.ts
@@ -1,0 +1,15 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatListModule } from '@angular/material/list';
+import { MatIconModule } from '@angular/material/icon';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-side-menu',
+  standalone: true,
+  imports: [CommonModule, MatListModule, MatIconModule, RouterModule],
+  templateUrl: './side-menu.component.html',
+})
+export class SideMenuComponent {
+  @Output() close = new EventEmitter<void>();
+}


### PR DESCRIPTION
## Summary
- Add standalone SideMenu component for navigation links
- Wrap app content in a Material sidenav container and toolbar with menu button
- Update styles for sidenav layout

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ffdc511c8331b0b004cfcda4fd01