### PR TITLE
fix: pin top menu in Angular app

### DIFF
--- a/mobile/calorie-counter/src/app/app.component.scss
+++ b/mobile/calorie-counter/src/app/app.component.scss
@@ -17,11 +17,14 @@
 }
 
 .topbar {
-  position: sticky;
+  position: fixed;
   top: 0;
-  z-index: 10;
+  left: 0;
+  right: 0;
+  z-index: 1000;
 }
 
 .container {
   padding: 12px;
+  margin-top: 64px;
 }


### PR DESCRIPTION
## Summary
- Fix top toolbar by switching to fixed positioning
- Add margin to content container so it appears below toolbar

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b424e0c63483319da054cd8790cb34