### PR TITLE
Fix side menu item layout

### DIFF
--- a/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.html
+++ b/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.html
@@ -1,22 +1,22 @@
 <mat-nav-list>
   <a mat-list-item routerLink="/history" (click)="close.emit()">
-    <mat-icon>history</mat-icon>
-    <span>История</span>
+    <mat-icon matListItemIcon>history</mat-icon>
+    <span matListItemTitle>История</span>
   </a>
   <a mat-list-item routerLink="/add" (click)="close.emit()">
-    <mat-icon>add_a_photo</mat-icon>
-    <span>Добавить</span>
+    <mat-icon matListItemIcon>add_a_photo</mat-icon>
+    <span matListItemTitle>Добавить</span>
   </a>
   <a mat-list-item routerLink="/analysis" (click)="close.emit()">
-    <mat-icon>analytics</mat-icon>
-    <span>Анализ</span>
+    <mat-icon matListItemIcon>analytics</mat-icon>
+    <span matListItemTitle>Анализ</span>
   </a>
   <a mat-list-item routerLink="/stats" (click)="close.emit()">
-    <mat-icon>bar_chart</mat-icon>
-    <span>Статистика</span>
+    <mat-icon matListItemIcon>bar_chart</mat-icon>
+    <span matListItemTitle>Статистика</span>
   </a>
   <a mat-list-item routerLink="/profile" (click)="close.emit()">
-    <mat-icon>person</mat-icon>
-    <span>Профиль</span>
+    <mat-icon matListItemIcon>person</mat-icon>
+    <span matListItemTitle>Профиль</span>
   </a>
 </mat-nav-list>

--- a/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.scss
+++ b/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.scss
@@ -1,0 +1,10 @@
+a.mat-list-item {
+  display: flex;
+  align-items: center;
+}
+
+mat-icon {
+  vertical-align: middle;
+  font-size: 24px;
+  margin-right: 8px;
+}

--- a/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.ts
+++ b/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.ts
@@ -9,6 +9,7 @@ import { RouterModule } from '@angular/router';
   standalone: true,
   imports: [CommonModule, MatListModule, MatIconModule, RouterModule],
   templateUrl: './side-menu.component.html',
+  styleUrls: ['./side-menu.component.scss'],
 })
 export class SideMenuComponent {
   @Output() close = new EventEmitter<void>();


### PR DESCRIPTION
## Summary
- Ensure side menu icons and labels render on one line using Angular Material's `matListItemIcon` and `matListItemTitle`
- Add component stylesheet aligning items horizontally and spacing icons

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b5549b4d6c8331b4a7b03a50297187