### PR TITLE
feat: style side menu icons

### DIFF
--- a/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.html
+++ b/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.html
@@ -1,22 +1,22 @@
 <mat-nav-list>
   <a mat-list-item routerLink="/history" (click)="close.emit()">
-    <mat-icon matListItemIcon>history</mat-icon>
+    <mat-icon fontSet="material-icons-outlined" matListItemIcon>history</mat-icon>
     <span matListItemTitle>История</span>
   </a>
   <a mat-list-item routerLink="/add" (click)="close.emit()">
-    <mat-icon matListItemIcon>add_a_photo</mat-icon>
+    <mat-icon fontSet="material-icons-outlined" matListItemIcon>add_a_photo</mat-icon>
     <span matListItemTitle>Добавить</span>
   </a>
   <a mat-list-item routerLink="/analysis" (click)="close.emit()">
-    <mat-icon matListItemIcon>analytics</mat-icon>
+    <mat-icon fontSet="material-icons-outlined" matListItemIcon>analytics</mat-icon>
     <span matListItemTitle>Анализ</span>
   </a>
   <a mat-list-item routerLink="/stats" (click)="close.emit()">
-    <mat-icon matListItemIcon>bar_chart</mat-icon>
+    <mat-icon fontSet="material-icons-outlined" matListItemIcon>bar_chart</mat-icon>
     <span matListItemTitle>Статистика</span>
   </a>
   <a mat-list-item routerLink="/profile" (click)="close.emit()">
-    <mat-icon matListItemIcon>person</mat-icon>
+    <mat-icon fontSet="material-icons-outlined" matListItemIcon>person</mat-icon>
     <span matListItemTitle>Профиль</span>
   </a>
 </mat-nav-list>

--- a/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.scss
+++ b/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.scss
@@ -1,10 +1,22 @@
 a.mat-list-item {
   display: flex;
   align-items: center;
+  margin-bottom: 15px;
+  font-size: 16px;
+  text-decoration: none;
 }
 
 mat-icon {
   vertical-align: middle;
-  font-size: 24px;
-  margin-right: 8px;
+  font-size: 20px;
+  margin-right: 10px;
+  color: #4877A6;
+}
+
+span[matListItemTitle] {
+  color: #2B2B2B;
+}
+
+a.mat-list-item:hover {
+  opacity: 0.8;
 }

--- a/mobile/calorie-counter/src/index.html
+++ b/mobile/calorie-counter/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet">
   <!-- Материальные иконки (для <mat-icon>) -->
 
   <!-- __FOODBOTOS_ENV__ -->

--- a/mobile/calorie-counter/src/styles.scss
+++ b/mobile/calorie-counter/src/styles.scss
@@ -24,4 +24,8 @@
 @import "@fontsource/material-icons-sharp/index.css";
 
 html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+body {
+  margin: 0;
+  font-family: "Roboto", sans-serif;
+  background: #f0f2f5;
+}


### PR DESCRIPTION
## Summary
- use outlined Material icons for the side menu
- style menu with blue icons, neutral text, and Roboto font
- set light background and include Roboto font CDN

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b563adcd9c8331b8cda08ebb8953b5