### PR TITLE
fix: prevent sidenav auto focus

### DIFF
--- a/mobile/calorie-counter/src/app/app.component.html
+++ b/mobile/calorie-counter/src/app/app.component.html
@@ -1,5 +1,5 @@
 <mat-sidenav-container class="app-shell">
-  <mat-sidenav #drawer mode="over" class="app-drawer" fixedInViewport>
+  <mat-sidenav #drawer mode="over" class="app-drawer" fixedInViewport [autoFocus]="false">
     <app-side-menu (close)="drawer.close()"></app-side-menu>
   </mat-sidenav>
 


### PR DESCRIPTION
## Summary
- prevent side navigation from auto-focusing the first link so nothing is pre-highlighted

## Testing
- `npm test` (fails: No binary for Chrome browser on your platform)


------
https://chatgpt.com/codex/tasks/task_e_68b56dbfdc1483318d3b0283edb9962e