### PR TITLE
Wrap ingredients text in history detail dialog

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
@@ -38,7 +38,13 @@
 }
 
 .macros { font-size: 13px; line-height: 1.2; }
-.ingredients { font-size: 12.5px; line-height: 1.2; }
+/* длинные ингредиенты будут переноситься */
+.ingredients {
+  font-size: 12.5px;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
 
 /* Таблица компактная, не на всю ширину */
 .composition { align-self: flex-start; max-width: 100%; overflow-x: auto; }


### PR DESCRIPTION
## Summary
- allow long ingredient lists to wrap within history detail dialog

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b57ae019108331b9d74b57ed9d1d8c