### PR TITLE
Ensure ingredients line wraps within photo width

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.html
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.html
@@ -1,5 +1,6 @@
 <div class="container">
   <img
+    #photo
     *ngIf="data.item.hasImage && data.imageUrl"
     [src]="data.imageUrl"
     alt="meal"

--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit } from "@angular/core";
+import { Component, Inject, OnInit, ViewChild, ElementRef } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { MatButtonModule } from "@angular/material/button";
 import { MatDialog, MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
@@ -24,6 +24,8 @@ import { HistoryClarifyDialogComponent } from "./history-clarify.dialog";
 export class HistoryDetailDialogComponent implements OnInit {
   displayedColumns = ['name','percent','grams','proteins_g','fats_g','carbs_g','calories_kcal'];
 
+  @ViewChild('photo') photo?: ElementRef<HTMLImageElement>;
+
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: { item: MealListItem; imageUrl: string },
     private api: FoodbotApiService,
@@ -48,8 +50,12 @@ export class HistoryDetailDialogComponent implements OnInit {
 
   /** Аккуратно подгоняет высоту диалога под контент */
   fitDialog() {
-    // UpdateSize ставит стиль на .cdk-overlay-pane; '' = не менять ширину, 'auto' = высота по контенту
-    Promise.resolve().then(() => this.dialogRef.updateSize('', 'auto'));
+    // UpdateSize ставит стиль на .cdk-overlay-pane;
+    // ширину подгоняем под фото, высоту — по контенту
+    Promise.resolve().then(() => {
+      const w = this.photo?.nativeElement?.width;
+      this.dialogRef.updateSize(w ? w + 'px' : '', 'auto');
+    });
   }
 
   openClarify() {


### PR DESCRIPTION
## Summary
- adjust HistoryDetailDialogComponent to size dialog width to the displayed photo
- add template reference for meal photo to measure its rendered width

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b57f260c7c8331a90b625171385b2b