### PR TITLE
Fix history dialog width to match image

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
@@ -30,8 +30,10 @@
 }
 
 .photo {
-  width: 100%;
+  align-self: center;
+  width: auto;
   height: auto;
+  max-width: 100%;
   max-height: 55vh;
   border-radius: 6px;
   object-fit: contain;

--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
@@ -51,10 +51,22 @@ export class HistoryDetailDialogComponent implements OnInit {
   /** Аккуратно подгоняет высоту диалога под контент */
   fitDialog() {
     // UpdateSize ставит стиль на .cdk-overlay-pane;
-    // ширину подгоняем под фото, высоту — по контенту
+    // ширину подгоняем под фото с учетом размеров экрана
     Promise.resolve().then(() => {
-      const w = this.photo?.nativeElement?.width;
-      this.dialogRef.updateSize(w ? w + 'px' : '', 'auto');
+      const img = this.photo?.nativeElement;
+      if (!img) {
+        this.dialogRef.updateSize('', 'auto');
+        return;
+      }
+      const maxW = window.innerWidth * 0.9;
+      const maxH = window.innerHeight * 0.55;
+      let w = img.naturalWidth;
+      const h = img.naturalHeight;
+      if (h > maxH) {
+        w = w * (maxH / h);
+      }
+      w = Math.min(w, maxW);
+      this.dialogRef.updateSize(`${Math.round(w)}px`, 'auto');
     });
   }
 


### PR DESCRIPTION
## Summary
- Keep meal photo at natural width and center it
- Resize history details dialog based on image dimensions and viewport limits

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b582ce01148331a45348ecb69166f2