### PR TITLE
feat: server-side voice transcription for history dialog

### DIFF
--- a/FoodBot/Controllers/SttController.cs
+++ b/FoodBot/Controllers/SttController.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FoodBot.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FoodBot.Controllers;
+
+[ApiController]
+[Route("api/stt")]
+[Authorize(AuthenticationSchemes = "Bearer")]
+public sealed class SttController : ControllerBase
+{
+    private readonly SpeechToTextService _stt;
+
+    public SttController(SpeechToTextService stt)
+    {
+        _stt = stt;
+    }
+
+    [HttpPost]
+    [RequestSizeLimit(30_000_000)]
+    public async Task<IActionResult> Transcribe([FromForm] IFormFile audio, [FromForm] string? language, CancellationToken ct)
+    {
+        if (audio == null || audio.Length == 0) return BadRequest("audio required");
+
+        await using var ms = new MemoryStream();
+        await audio.CopyToAsync(ms, ct);
+        var bytes = ms.ToArray();
+
+        var text = await _stt.TranscribeAsync(bytes, language ?? "ru", audio.FileName ?? "audio", audio.ContentType ?? "application/octet-stream", ct);
+        if (string.IsNullOrWhiteSpace(text)) return BadRequest("stt_failed");
+
+        return Ok(new { text });
+    }
+}
+

--- a/mobile/calorie-counter/src/app/services/foodbot-api.service.ts
+++ b/mobile/calorie-counter/src/app/services/foodbot-api.service.ts
@@ -55,6 +55,13 @@ export class FoodbotApiService {
     return this.http.post<ClarifyResult>(`${this.baseUrl}/api/meals/${mealId}/clarify-voice`, form);
   }
 
+  transcribeVoice(file: File, language = "ru"): Observable<{ text: string }> {
+    const form = new FormData();
+    form.append("audio", file, file.name);
+    form.append("language", language);
+    return this.http.post<{ text: string }>(`${this.baseUrl}/api/stt`, form);
+  }
+
   // Отчёт Excel
   getReport(): Observable<Blob> {
     return this.http.get(`${this.baseUrl}/api/meals/report`, { responseType: "blob" as const });


### PR DESCRIPTION
## Summary
- record audio on mic hold in history clarification dialog
- add API service and STT endpoint for server speech recognition

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b5972a794483319df40f05d36bbb36