### PR TITLE
refactor: enhance history clarify dialog

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history-clarify.dialog.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history-clarify.dialog.ts
@@ -31,14 +31,17 @@ import { firstValueFrom } from 'rxjs';
     <div mat-dialog-content class="content">
       <mat-form-field appearance="fill" class="note-field">
         <mat-label>Текст</mat-label>
-        <textarea matInput [(ngModel)]="note"></textarea>
+        <textarea matInput rows="5" [(ngModel)]="note"></textarea>
       </mat-form-field>
-      <button mat-icon-button color="primary"
-              (mousedown)="startRecord($event)" (touchstart)="startRecord($event)"
-              (mouseup)="stopRecord()" (mouseleave)="stopRecord()" (touchend)="stopRecord()"
-              [disabled]="transcribing">
-        <mat-icon>mic</mat-icon>
-      </button>
+      <div class="mic-area">
+        <button mat-icon-button color="primary"
+                (mousedown)="startRecord($event)" (touchstart)="startRecord($event)"
+                (mouseup)="stopRecord()" (mouseleave)="stopRecord()" (touchend)="stopRecord()"
+                [disabled]="transcribing">
+          <mat-icon>mic</mat-icon>
+        </button>
+        <div class="mic-hint">Удерживайте кнопку для записи</div>
+      </div>
     </div>
     <div class="overlay" *ngIf="transcribing">
       <mat-spinner></mat-spinner>
@@ -50,8 +53,11 @@ import { firstValueFrom } from 'rxjs';
     </div>
   `,
   styles: [`
-    .content { display: flex; align-items: flex-start; gap: 8px; }
+    .content { display: flex; align-items: flex-start; gap: 16px; }
     .note-field { flex: 1; }
+    .note-field textarea { min-height: 120px; }
+    .mic-area { display: flex; flex-direction: column; align-items: center; }
+    .mic-hint { font-size: 12px; margin-top: 4px; text-align: center; color: rgba(0,0,0,0.6); }
     :host { display: block; position: relative; }
     .overlay {
       position: absolute;


### PR DESCRIPTION
## Summary
- enlarge HistoryClarifyDialogComponent text field and arrange layout with mic hint

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c74edad08331969db1d4f6446ebc