### PR TITLE
feat: allow updating meal time

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
@@ -71,7 +71,9 @@ export class HistoryDetailDialogComponent implements OnInit {
   }
 
   openClarify() {
-    const ref = this.dialog.open(HistoryClarifyDialogComponent, { data: { mealId: this.data.item.id } });
+    const ref = this.dialog.open(HistoryClarifyDialogComponent, {
+      data: { mealId: this.data.item.id, createdAtUtc: this.data.item.createdAtUtc }
+    });
     ref.afterClosed().subscribe((r: ClarifyResult | { deleted: true } | undefined) => {
       if (!r) return;
       if ((r as any).deleted) {
@@ -80,6 +82,7 @@ export class HistoryDetailDialogComponent implements OnInit {
         return;
       }
       const res = r as ClarifyResult;
+      this.data.item.createdAtUtc = res.createdAtUtc;
       this.data.item.dishName = res.result.dish;
       this.data.item.caloriesKcal = res.result.calories_kcal;
       this.data.item.proteinsG = res.result.proteins_g;

--- a/mobile/calorie-counter/src/app/services/foodbot-api.service.ts
+++ b/mobile/calorie-counter/src/app/services/foodbot-api.service.ts
@@ -45,8 +45,11 @@ export class FoodbotApiService {
   }
 
   // Уточнения
-  clarifyText(mealId: number, note: string): Observable<ClarifyResult> {
-    return this.http.post<ClarifyResult>(`${this.baseUrl}/api/meals/${mealId}/clarify-text`, { note });
+  clarifyText(mealId: number, note?: string, time?: string): Observable<ClarifyResult> {
+    const body: any = {};
+    if (note) body.note = note;
+    if (time) body.time = time;
+    return this.http.post<ClarifyResult>(`${this.baseUrl}/api/meals/${mealId}/clarify-text`, body);
   }
   clarifyVoice(mealId: number, file: File, language = "ru"): Observable<ClarifyResult> {
     const form = new FormData();

--- a/mobile/calorie-counter/src/app/services/foodbot-api.types.ts
+++ b/mobile/calorie-counter/src/app/services/foodbot-api.types.ts
@@ -77,6 +77,7 @@ export interface UploadResult {
 
 export interface ClarifyResult {
   id: number;
+  createdAtUtc: string;
   result: NutritionResult;
   products: ProductInfo[];
   step1: Step1Snapshot;


### PR DESCRIPTION
## Summary
- allow clarifying only meal time without resending note
- skip nutrition recalculation when only time changes and return updated timestamp
- expose createdAtUtc in clarify responses and update client accordingly

## Testing
- `dotnet build FoodBot` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b6df446bf08331b6033cf658f1f9de