### PR TITLE
fix(history): expose initial time for template

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history-clarify.dialog.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history-clarify.dialog.ts
@@ -83,7 +83,7 @@ export class HistoryClarifyDialogComponent {
   private recorder?: MediaRecorder;
   private chunks: Blob[] = [];
   private createdAt: Date;
-  private initialTime: string;
+  readonly initialTime: string;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: { mealId: number; createdAtUtc: string },


### PR DESCRIPTION
## Summary
- make `initialTime` public so template can access it

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e727844883318afcb97af1842480