### PR TITLE
Use local timezone for meal clarification

### DIFF
--- a/FoodBot/Controllers/MealsApiController.cs
+++ b/FoodBot/Controllers/MealsApiController.cs
@@ -227,7 +227,7 @@ namespace FoodBot.Controllers
             {
                 if (req.time.HasValue)
                 {
-                    m.CreatedAtUtc = req.time.Value;
+                    m.CreatedAtUtc = req.time.Value.ToUniversalTime();
                     await _db.SaveChangesAsync(ct);
                 }
 
@@ -304,7 +304,7 @@ namespace FoodBot.Controllers
             m.WeightG = conv2.Result.weight_g;
             m.ReasoningPrompt = conv2.ReasoningPrompt;
             if (req.time.HasValue)
-                m.CreatedAtUtc = req.time.Value;
+                m.CreatedAtUtc = req.time.Value.ToUniversalTime();
 
             await _db.SaveChangesAsync(ct);
 

--- a/mobile/calorie-counter/src/app/pages/history/history-clarify.dialog.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history-clarify.dialog.ts
@@ -92,7 +92,8 @@ export class HistoryClarifyDialogComponent {
     public dialogRef: MatDialogRef<HistoryClarifyDialogComponent>
   ) {
     this.createdAt = new Date(data.createdAtUtc);
-    this.time = this.createdAt.toISOString().substring(11, 16);
+    const pad = (n: number) => n.toString().padStart(2, '0');
+    this.time = `${pad(this.createdAt.getHours())}:${pad(this.createdAt.getMinutes())}`;
     this.initialTime = this.time;
   }
 


### PR DESCRIPTION
## Summary
- Display time in HistoryClarify dialog using client local timezone
- Store clarified meal time in UTC on server side

## Testing
- `dotnet test FoodBot/FoodBot.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `npm test -- --watch=false --browsers=ChromiumHeadless` *(fails: ChromiumHeadless cannot start; requires snap)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ee0f16a48331b8bcfdc0f1cb5669