### PR TITLE
Fix pending meal processing

### DIFF
--- a/FoodBot/Services/PhotoQueueWorker.cs
+++ b/FoodBot/Services/PhotoQueueWorker.cs
@@ -53,7 +53,7 @@ public sealed class PhotoQueueWorker : BackgroundService
                             UserId = 0,
                             Username = "app",
                             CreatedAtUtc = DateTimeOffset.UtcNow,
-                            FileId = null,
+                            FileId = string.Empty,
                             FileMime = next.FileMime,
                             ImageBytes = next.ImageBytes,
                             DishName = conv.Result.dish,


### PR DESCRIPTION
## Summary
- avoid null FileId when creating MealEntry so pending photos become meals

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b705b564c883318780673f409fa2c1