### PR TITLE
refactor: add services and tests

### DIFF
--- a/FoodBot.Tests/FoodBot.Tests.csproj
+++ b/FoodBot.Tests/FoodBot.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../FoodBot/FoodBot.csproj" />
+  </ItemGroup>
+</Project>

--- a/FoodBot.Tests/MealServiceTests.cs
+++ b/FoodBot.Tests/MealServiceTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FoodBot.Data;
+using FoodBot.Services;
+using Xunit;
+
+public class MealServiceTests
+{
+    private MealService CreateService(List<MealEntry> meals)
+    {
+        var repo = new FakeRepo(meals);
+        return new MealService(repo);
+    }
+
+    private sealed class FakeRepo : IMealRepository
+    {
+        public List<MealEntry> MealsData;
+        public List<PendingMeal> PendingMealData = new();
+        public List<PendingClarify> PendingClarifyData = new();
+        public FakeRepo(List<MealEntry> meals) { MealsData = meals; }
+        public IQueryable<MealEntry> Meals => MealsData.AsQueryable();
+        public IQueryable<PendingMeal> PendingMeals => PendingMealData.AsQueryable();
+        public IQueryable<PendingClarify> PendingClarifies => PendingClarifyData.AsQueryable();
+        public Task QueuePendingMealAsync(PendingMeal meal, CancellationToken ct)
+        { PendingMealData.Add(meal); return Task.CompletedTask; }
+        public Task QueuePendingClarifyAsync(PendingClarify clarify, CancellationToken ct)
+        { PendingClarifyData.Add(clarify); return Task.CompletedTask; }
+        public Task RemoveMealAsync(MealEntry meal, CancellationToken ct)
+        { MealsData.Remove(meal); return Task.CompletedTask; }
+        public Task SaveChangesAsync(CancellationToken ct) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsMealsForChat()
+    {
+        var meals = new List<MealEntry>
+        {
+            new MealEntry { Id = 1, ChatId = 1, CreatedAtUtc = DateTimeOffset.UtcNow },
+            new MealEntry { Id = 2, ChatId = 1, CreatedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-1) },
+            new MealEntry { Id = 3, ChatId = 2, CreatedAtUtc = DateTimeOffset.UtcNow }
+        };
+        var service = CreateService(meals);
+        var res = await service.ListAsync(1, 10, 0, CancellationToken.None);
+        Assert.Equal(2, res.Total);
+        Assert.Equal(2, res.Items.Count);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesMeal()
+    {
+        var meals = new List<MealEntry>
+        {
+            new MealEntry { Id = 1, ChatId = 1, CreatedAtUtc = DateTimeOffset.UtcNow }
+        };
+        var service = CreateService(meals);
+        var ok = await service.DeleteAsync(1, 1, CancellationToken.None);
+        Assert.True(ok);
+        Assert.Empty(meals);
+        ok = await service.DeleteAsync(1, 1, CancellationToken.None);
+        Assert.False(ok);
+    }
+}

--- a/FoodBot/Controllers/AppAuthController.cs
+++ b/FoodBot/Controllers/AppAuthController.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using FoodBot.Data;
 using FoodBot.Services;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace FoodBot.Controllers
 {
@@ -14,25 +11,11 @@ namespace FoodBot.Controllers
     [Route("api/auth")]
     public sealed class AppAuthController : ControllerBase
     {
-        private readonly BotDbContext _db;
-        private readonly JwtService _jwt;
-        private readonly IConfiguration _cfg;
+        private readonly IAppAuthService _auth;
 
-        public AppAuthController(BotDbContext db, JwtService jwt, IConfiguration cfg)
+        public AppAuthController(IAppAuthService auth)
         {
-            _db = db;
-            _jwt = jwt;
-            _cfg = cfg;
-        }
-
-        private static string GenerateCode(int length = 8)
-        {
-            const string alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // без похожих символов
-            var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
-            var bytes = new byte[length];
-            rng.GetBytes(bytes);
-            var chars = bytes.Select(b => alphabet[b % alphabet.Length]);
-            return new string(chars.ToArray());
+            _auth = auth;
         }
 
         public sealed record RequestCodeResponse(string code, DateTimeOffset expiresAtUtc);
@@ -42,24 +25,8 @@ namespace FoodBot.Controllers
         [HttpPost("request-code")]
         public async Task<ActionResult<RequestCodeResponse>> RequestCode(CancellationToken ct)
         {
-            var now = DateTimeOffset.UtcNow;
-            var ttlMin = int.TryParse(_cfg["Auth:StartCodeMinutes"], out var m) ? m : 15;
-
-            string code;
-            // гарантируем уникальность кода
-            do { code = GenerateCode(8); }
-            while (await _db.StartCodes.AnyAsync(x => x.Code == code && x.ConsumedAtUtc == null && x.ExpiresAtUtc > now, ct));
-
-            var row = new AppStartCode
-            {
-                Code = code,
-                CreatedAtUtc = now,
-                ExpiresAtUtc = now.AddMinutes(ttlMin)
-            };
-            _db.StartCodes.Add(row);
-            await _db.SaveChangesAsync(ct);
-
-            return Ok(new RequestCodeResponse(code, row.ExpiresAtUtc));
+            var resp = await _auth.RequestCodeAsync(ct);
+            return Ok(resp);
         }
 
         public sealed record StatusResponse(bool linked, DateTimeOffset expiresAtUtc, int secondsLeft);
@@ -69,15 +36,9 @@ namespace FoodBot.Controllers
         [HttpGet("status")]
         public async Task<ActionResult<StatusResponse>> Status([FromQuery, Required] string code, CancellationToken ct)
         {
-            var now = DateTimeOffset.UtcNow;
-            var row = await _db.StartCodes.FirstOrDefaultAsync(x => x.Code == code, ct);
-            if (row is null) return NotFound(new { error = "not_found" });
-
-            if (row.ExpiresAtUtc <= now) return Ok(new StatusResponse(false, row.ExpiresAtUtc, 0));
-            var left = (int)Math.Max(0, (row.ExpiresAtUtc - now).TotalSeconds);
-
-            var linked = row.ChatId.HasValue;
-            return Ok(new StatusResponse(linked, row.ExpiresAtUtc, left));
+            var resp = await _auth.GetStatusAsync(code, ct);
+            if (resp is null) return NotFound(new { error = "not_found" });
+            return Ok(resp);
         }
 
         public sealed record ExchangeRequest([Required] string code, string? device);
@@ -88,25 +49,10 @@ namespace FoodBot.Controllers
         [HttpPost("exchange-startcode")]
         public async Task<ActionResult<ExchangeResponse>> ExchangeStartCode([FromBody] ExchangeRequest req, CancellationToken ct)
         {
-            var now = DateTimeOffset.UtcNow;
-            var row = await _db.StartCodes.FirstOrDefaultAsync(x => x.Code == req.code, ct);
-            if (row is null) return BadRequest(new { error = "not_found" });
-            if (row.ExpiresAtUtc <= now) return BadRequest(new { error = "expired" });
-            if (row.ConsumedAtUtc is not null) return BadRequest(new { error = "already_used" });
-
-            if (row.ChatId is null)
-            {
-                // ещё не ввели код в боте
-                return Ok(new { status = "pending" });
-            }
-
-            // выдаём JWT и помечаем как использованный
-            var jwt = _jwt.Issue(row.ChatId.Value);
-            var hours = int.TryParse(_cfg["Auth:AccessTokenHours"], out var h) ? h : 72;
-            row.ConsumedAtUtc = now;
-            await _db.SaveChangesAsync(ct);
-
-            return Ok(new ExchangeResponse(jwt, "Bearer", hours * 3600, row.ChatId.Value));
+            var res = await _auth.ExchangeStartCodeAsync(req.code, ct);
+            if (res.Error != null) return BadRequest(new { error = res.Error });
+            if (res.Pending) return Ok(new { status = "pending" });
+            return Ok(res.Response);
         }
     }
 }

--- a/FoodBot/FoodBot.sln
+++ b/FoodBot/FoodBot.sln
@@ -4,17 +4,23 @@ VisualStudioVersion = 17.10.34729.65
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FoodBot", "FoodBot.csproj", "{8E0B27A7-9F8B-4F44-95C2-1E7F4A6B6D87}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FoodBot.Tests", "..\\FoodBot.Tests\\FoodBot.Tests.csproj", "{3404C33F-1264-49E9-A520-9E551FC40D81}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{8E0B27A7-9F8B-4F44-95C2-1E7F4A6B6D87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8E0B27A7-9F8B-4F44-95C2-1E7F4A6B6D87}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8E0B27A7-9F8B-4F44-95C2-1E7F4A6B6D87}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8E0B27A7-9F8B-4F44-95C2-1E7F4A6B6D87}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {8E0B27A7-9F8B-4F44-95C2-1E7F4A6B6D87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {8E0B27A7-9F8B-4F44-95C2-1E7F4A6B6D87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {8E0B27A7-9F8B-4F44-95C2-1E7F4A6B6D87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {8E0B27A7-9F8B-4F44-95C2-1E7F4A6B6D87}.Release|Any CPU.Build.0 = Release|Any CPU
+                {3404C33F-1264-49E9-A520-9E551FC40D81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {3404C33F-1264-49E9-A520-9E551FC40D81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {3404C33F-1264-49E9-A520-9E551FC40D81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {3404C33F-1264-49E9-A520-9E551FC40D81}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/FoodBot/Program.cs
+++ b/FoodBot/Program.cs
@@ -56,6 +56,9 @@ builder.Services.AddScoped<TelegramReportService>();
 builder.Services.AddScoped<StatsService>();
 builder.Services.AddScoped<PersonalCardService>();
 builder.Services.AddScoped<DietAnalysisService>();
+builder.Services.AddScoped<IMealRepository, MealRepository>();
+builder.Services.AddScoped<IMealService, MealService>();
+builder.Services.AddScoped<IAppAuthService, AppAuthService>();
 builder.Services.AddHostedService<AnalysisQueueWorker>();
 builder.Services.AddHostedService<PhotoQueueWorker>();
 

--- a/FoodBot/Services/AppAuthService.cs
+++ b/FoodBot/Services/AppAuthService.cs
@@ -1,0 +1,78 @@
+using FoodBot.Data;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+
+namespace FoodBot.Services;
+
+public sealed class AppAuthService : IAppAuthService
+{
+    private readonly BotDbContext _db;
+    private readonly JwtService _jwt;
+    private readonly IConfiguration _cfg;
+
+    public AppAuthService(BotDbContext db, JwtService jwt, IConfiguration cfg)
+    {
+        _db = db;
+        _jwt = jwt;
+        _cfg = cfg;
+    }
+
+    private static string GenerateCode(int length = 8)
+    {
+        const string alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+        var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
+        var bytes = new byte[length];
+        rng.GetBytes(bytes);
+        var chars = bytes.Select(b => alphabet[b % alphabet.Length]);
+        return new string(chars.ToArray());
+    }
+
+    public async Task<RequestCodeResponse> RequestCodeAsync(CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var ttlMin = int.TryParse(_cfg["Auth:StartCodeMinutes"], out var m) ? m : 15;
+
+        string code;
+        do { code = GenerateCode(8); }
+        while (await _db.StartCodes.AnyAsync(x => x.Code == code && x.ConsumedAtUtc == null && x.ExpiresAtUtc > now, ct));
+
+        var row = new AppStartCode
+        {
+            Code = code,
+            CreatedAtUtc = now,
+            ExpiresAtUtc = now.AddMinutes(ttlMin)
+        };
+        _db.StartCodes.Add(row);
+        await _db.SaveChangesAsync(ct);
+
+        return new RequestCodeResponse(code, row.ExpiresAtUtc);
+    }
+
+    public async Task<StatusResponse?> GetStatusAsync(string code, CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var row = await _db.StartCodes.FirstOrDefaultAsync(x => x.Code == code, ct);
+        if (row is null) return null;
+        if (row.ExpiresAtUtc <= now) return new StatusResponse(false, row.ExpiresAtUtc, 0);
+        var left = (int)Math.Max(0, (row.ExpiresAtUtc - now).TotalSeconds);
+        var linked = row.ChatId.HasValue;
+        return new StatusResponse(linked, row.ExpiresAtUtc, left);
+    }
+
+    public async Task<ExchangeStartCodeResult> ExchangeStartCodeAsync(string code, CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var row = await _db.StartCodes.FirstOrDefaultAsync(x => x.Code == code, ct);
+        if (row is null) return new ExchangeStartCodeResult("not_found", false, null);
+        if (row.ExpiresAtUtc <= now) return new ExchangeStartCodeResult("expired", false, null);
+        if (row.ConsumedAtUtc is not null) return new ExchangeStartCodeResult("already_used", false, null);
+        if (row.ChatId is null) return new ExchangeStartCodeResult(null, true, null);
+
+        var jwt = _jwt.Issue(row.ChatId.Value);
+        var hours = int.TryParse(_cfg["Auth:AccessTokenHours"], out var h) ? h : 72;
+        row.ConsumedAtUtc = now;
+        await _db.SaveChangesAsync(ct);
+        var resp = new ExchangeResponse(jwt, "Bearer", hours * 3600, row.ChatId.Value);
+        return new ExchangeStartCodeResult(null, false, resp);
+    }
+}

--- a/FoodBot/Services/IAppAuthService.cs
+++ b/FoodBot/Services/IAppAuthService.cs
@@ -1,0 +1,13 @@
+namespace FoodBot.Services;
+
+public interface IAppAuthService
+{
+    Task<RequestCodeResponse> RequestCodeAsync(CancellationToken ct);
+    Task<StatusResponse?> GetStatusAsync(string code, CancellationToken ct);
+    Task<ExchangeStartCodeResult> ExchangeStartCodeAsync(string code, CancellationToken ct);
+}
+
+public sealed record RequestCodeResponse(string Code, DateTimeOffset ExpiresAtUtc);
+public sealed record StatusResponse(bool Linked, DateTimeOffset ExpiresAtUtc, int SecondsLeft);
+public sealed record ExchangeResponse(string AccessToken, string TokenType, int ExpiresInSeconds, long ChatId);
+public sealed record ExchangeStartCodeResult(string? Error, bool Pending, ExchangeResponse? Response);

--- a/FoodBot/Services/IMealRepository.cs
+++ b/FoodBot/Services/IMealRepository.cs
@@ -1,0 +1,15 @@
+using FoodBot.Data;
+
+namespace FoodBot.Services;
+
+public interface IMealRepository
+{
+    IQueryable<MealEntry> Meals { get; }
+    IQueryable<PendingMeal> PendingMeals { get; }
+    IQueryable<PendingClarify> PendingClarifies { get; }
+
+    Task QueuePendingMealAsync(PendingMeal meal, CancellationToken ct);
+    Task QueuePendingClarifyAsync(PendingClarify clarify, CancellationToken ct);
+    Task RemoveMealAsync(MealEntry meal, CancellationToken ct);
+    Task SaveChangesAsync(CancellationToken ct);
+}

--- a/FoodBot/Services/IMealService.cs
+++ b/FoodBot/Services/IMealService.cs
@@ -1,0 +1,50 @@
+using FoodBot.Data;
+
+namespace FoodBot.Services;
+
+public interface IMealService
+{
+    Task<MealListResult> ListAsync(long chatId, int limit, int offset, CancellationToken ct);
+    Task<MealDetails?> GetDetailsAsync(long chatId, int id, CancellationToken ct);
+    Task<(byte[] bytes, string mime)?> GetImageAsync(long chatId, int id, CancellationToken ct);
+    Task QueueImageAsync(long chatId, byte[] bytes, string fileMime, CancellationToken ct);
+    Task<ClarifyTextResult?> ClarifyTextAsync(long chatId, int id, string? note, DateTimeOffset? time, CancellationToken ct);
+    Task<bool> DeleteAsync(long chatId, int id, CancellationToken ct);
+}
+
+public sealed record MealListResult(int Total, int Offset, int Limit, List<MealListItem> Items);
+
+public sealed record MealListItem
+(
+    int Id,
+    DateTimeOffset CreatedAtUtc,
+    string? DishName,
+    decimal? WeightG,
+    decimal? CaloriesKcal,
+    decimal? ProteinsG,
+    decimal? FatsG,
+    decimal? CarbsG,
+    string[] Ingredients,
+    FoodBot.Models.ProductInfo[] Products,
+    bool HasImage
+);
+
+public sealed record MealDetails
+(
+    int Id,
+    DateTimeOffset CreatedAtUtc,
+    string? DishName,
+    decimal? WeightG,
+    decimal? CaloriesKcal,
+    decimal? ProteinsG,
+    decimal? FatsG,
+    decimal? CarbsG,
+    decimal? Confidence,
+    string[] Ingredients,
+    FoodBot.Models.ProductInfo[] Products,
+    Step1Snapshot? Step1,
+    string? ReasoningPrompt,
+    bool HasImage
+);
+
+public sealed record ClarifyTextResult(bool Queued, MealDetails? Details);

--- a/FoodBot/Services/MealRepository.cs
+++ b/FoodBot/Services/MealRepository.cs
@@ -1,0 +1,37 @@
+using FoodBot.Data;
+
+namespace FoodBot.Services;
+
+public sealed class MealRepository : IMealRepository
+{
+    private readonly BotDbContext _db;
+
+    public MealRepository(BotDbContext db)
+    {
+        _db = db;
+    }
+
+    public IQueryable<MealEntry> Meals => _db.Meals;
+    public IQueryable<PendingMeal> PendingMeals => _db.PendingMeals;
+    public IQueryable<PendingClarify> PendingClarifies => _db.PendingClarifies;
+
+    public Task QueuePendingMealAsync(PendingMeal meal, CancellationToken ct)
+    {
+        _db.PendingMeals.Add(meal);
+        return _db.SaveChangesAsync(ct);
+    }
+
+    public Task QueuePendingClarifyAsync(PendingClarify clarify, CancellationToken ct)
+    {
+        _db.PendingClarifies.Add(clarify);
+        return _db.SaveChangesAsync(ct);
+    }
+
+    public Task RemoveMealAsync(MealEntry meal, CancellationToken ct)
+    {
+        _db.Meals.Remove(meal);
+        return _db.SaveChangesAsync(ct);
+    }
+
+    public Task SaveChangesAsync(CancellationToken ct) => _db.SaveChangesAsync(ct);
+}

--- a/FoodBot/Services/MealService.cs
+++ b/FoodBot/Services/MealService.cs
@@ -1,0 +1,196 @@
+using System.Linq;
+using System.Text.Json;
+using FoodBot.Data;
+
+namespace FoodBot.Services;
+
+public sealed class MealService : IMealService
+{
+    private readonly IMealRepository _repo;
+
+    public MealService(IMealRepository repo)
+    {
+        _repo = repo;
+    }
+
+    public Task<MealListResult> ListAsync(long chatId, int limit, int offset, CancellationToken ct)
+    {
+        var baseQuery = _repo.Meals
+            .AsNoTracking()
+            .Where(m => m.ChatId == chatId)
+            .OrderByDescending(m => m.CreatedAtUtc);
+
+        var total = baseQuery.Count();
+
+        var rows = baseQuery
+            .Skip(offset)
+            .Take(limit)
+            .Select(m => new
+            {
+                m.Id,
+                m.CreatedAtUtc,
+                m.DishName,
+                m.WeightG,
+                m.CaloriesKcal,
+                m.ProteinsG,
+                m.FatsG,
+                m.CarbsG,
+                m.IngredientsJson,
+                m.ProductsJson,
+                HasImage = m.ImageBytes != null && m.ImageBytes.Length > 0
+            })
+            .ToList();
+
+        var items = rows.Select(r => new MealListItem(
+            r.Id,
+            r.CreatedAtUtc,
+            r.DishName,
+            r.WeightG,
+            r.CaloriesKcal,
+            r.ProteinsG,
+            r.FatsG,
+            r.CarbsG,
+            string.IsNullOrWhiteSpace(r.IngredientsJson)
+                ? Array.Empty<string>()
+                : (JsonSerializer.Deserialize<string[]>(r.IngredientsJson!) ?? Array.Empty<string>()),
+            ProductJsonHelper.DeserializeProducts(r.ProductsJson),
+            r.HasImage
+        )).ToList();
+
+        return Task.FromResult(new MealListResult(total, offset, limit, items));
+    }
+
+    public Task<MealDetails?> GetDetailsAsync(long chatId, int id, CancellationToken ct)
+    {
+        var m = _repo.Meals.AsNoTracking()
+            .FirstOrDefault(x => x.ChatId == chatId && x.Id == id);
+        if (m == null) return Task.FromResult<MealDetails?>(null);
+
+        var ingredients = string.IsNullOrWhiteSpace(m.IngredientsJson)
+            ? Array.Empty<string>()
+            : (JsonSerializer.Deserialize<string[]>(m.IngredientsJson!) ?? Array.Empty<string>());
+
+        Step1Snapshot? step1 = null;
+        if (!string.IsNullOrWhiteSpace(m.Step1Json))
+        {
+            try
+            {
+                step1 = JsonSerializer.Deserialize<Step1Snapshot>(m.Step1Json!, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            }
+            catch { }
+        }
+
+        var products = ProductJsonHelper.DeserializeProducts(m.ProductsJson);
+
+        var details = new MealDetails(
+            m.Id,
+            m.CreatedAtUtc,
+            m.DishName,
+            m.WeightG,
+            m.CaloriesKcal,
+            m.ProteinsG,
+            m.FatsG,
+            m.CarbsG,
+            m.Confidence,
+            ingredients,
+            products,
+            step1,
+            m.ReasoningPrompt,
+            m.ImageBytes != null && m.ImageBytes.Length > 0
+        );
+        return Task.FromResult<MealDetails?>(details);
+    }
+
+    public Task<(byte[] bytes, string mime)?> GetImageAsync(long chatId, int id, CancellationToken ct)
+    {
+        var m = _repo.Meals.AsNoTracking()
+            .Where(x => x.ChatId == chatId && x.Id == id)
+            .Select(x => new { x.ImageBytes, x.FileMime })
+            .FirstOrDefault();
+        if (m == null || m.ImageBytes == null || m.ImageBytes.Length == 0)
+            return Task.FromResult<(byte[] bytes, string mime)?>(null);
+        var mime = string.IsNullOrWhiteSpace(m.FileMime) ? "image/jpeg" : m.FileMime!;
+        return Task.FromResult<(byte[] bytes, string mime)?>(new(m.ImageBytes, mime));
+    }
+
+    public Task QueueImageAsync(long chatId, byte[] bytes, string fileMime, CancellationToken ct)
+    {
+        var pending = new PendingMeal
+        {
+            ChatId = chatId,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            FileMime = fileMime,
+            ImageBytes = bytes,
+            Attempts = 0
+        };
+        return _repo.QueuePendingMealAsync(pending, ct);
+    }
+
+    public async Task<ClarifyTextResult?> ClarifyTextAsync(long chatId, int id, string? note, DateTimeOffset? time, CancellationToken ct)
+    {
+        var m = _repo.Meals.FirstOrDefault(x => x.ChatId == chatId && x.Id == id);
+        if (m == null) return null;
+
+        if (string.IsNullOrWhiteSpace(note))
+        {
+            if (time.HasValue)
+            {
+                m.CreatedAtUtc = time.Value.ToUniversalTime();
+                await _repo.SaveChangesAsync(ct);
+            }
+
+            var ingredients = string.IsNullOrWhiteSpace(m.IngredientsJson)
+                ? Array.Empty<string>()
+                : (JsonSerializer.Deserialize<string[]>(m.IngredientsJson!) ?? Array.Empty<string>());
+
+            Step1Snapshot? step1 = null;
+            if (!string.IsNullOrWhiteSpace(m.Step1Json))
+            {
+                try
+                {
+                    step1 = JsonSerializer.Deserialize<Step1Snapshot>(m.Step1Json!, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                }
+                catch { }
+            }
+
+            var products = ProductJsonHelper.DeserializeProducts(m.ProductsJson);
+            var details = new MealDetails(
+                m.Id,
+                m.CreatedAtUtc,
+                m.DishName,
+                m.WeightG,
+                m.CaloriesKcal,
+                m.ProteinsG,
+                m.FatsG,
+                m.CarbsG,
+                m.Confidence,
+                ingredients,
+                products,
+                step1,
+                m.ReasoningPrompt,
+                m.ImageBytes != null && m.ImageBytes.Length > 0
+            );
+            return new ClarifyTextResult(false, details);
+        }
+
+        var pending = new PendingClarify
+        {
+            ChatId = chatId,
+            MealId = id,
+            Note = note!,
+            NewTime = time?.ToUniversalTime(),
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            Attempts = 0
+        };
+        await _repo.QueuePendingClarifyAsync(pending, ct);
+        return new ClarifyTextResult(true, null);
+    }
+
+    public async Task<bool> DeleteAsync(long chatId, int id, CancellationToken ct)
+    {
+        var m = _repo.Meals.FirstOrDefault(x => x.ChatId == chatId && x.Id == id);
+        if (m == null) return false;
+        await _repo.RemoveMealAsync(m, ct);
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce meal repository/service interfaces and implementations
- refactor auth and meals controllers to rely on services instead of DbContext
- add unit tests for meal service with a fake repository

## Testing
- `dotnet test FoodBot/FoodBot.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ec81af588331ae833de07cf8ec6d