### PR TITLE
Fix missing EF Core using for MealService AsNoTracking

### DIFF
--- a/FoodBot/Services/MealService.cs
+++ b/FoodBot/Services/MealService.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
 using FoodBot.Data;
 
 namespace FoodBot.Services;


### PR DESCRIPTION
## Summary
- add Microsoft.EntityFrameworkCore using to MealService for AsNoTracking

## Testing
- `dotnet test FoodBot/FoodBot.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b7ef04ef5083318b2c071eb010d9f0