### PR TITLE
Refactor session management for nutrition analysis

### DIFF
--- a/FoodBot/Models/NutritionSession.cs
+++ b/FoodBot/Models/NutritionSession.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using FoodBot.Services; // MatchedFoodRow
+
+namespace FoodBot.Models
+{
+    /// <summary>
+    /// Stores all data related to a nutrition analysis session.
+    /// </summary>
+    public class NutritionSession
+    {
+        public Guid Id { get; init; } = Guid.NewGuid();
+        public string ImageDataUrl { get; set; } = "";
+        public string[] Ingredients { get; set; } = Array.Empty<string>();
+        public MatchedFoodRow[] MatchedFoods { get; set; } = Array.Empty<MatchedFoodRow>();
+        public Step1Snapshot? Step1 { get; set; }
+        public List<object> History { get; } = new();
+    }
+}

--- a/FoodBot/Program.cs
+++ b/FoodBot/Program.cs
@@ -18,6 +18,9 @@ builder.Services.AddDbContext<BotDbContext>(opt =>
     opt.UseSqlServer(builder.Configuration.GetConnectionString("Sql")));
 
 builder.Services.AddHttpClient();
+builder.Services.AddMemoryCache();
+
+builder.Services.AddSingleton<INutritionSessionService, NutritionSessionService>();
 
 
 
@@ -44,8 +47,9 @@ builder.Services.AddSingleton<NutritionService>(sp =>
     var cfg = sp.GetRequiredService<IConfiguration>();
     var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
     var env = sp.GetRequiredService<IWebHostEnvironment>();
+    var sessions = sp.GetRequiredService<INutritionSessionService>();
     var ai = sp.GetRequiredService<IOpenAiClient>();
-    return new NutritionService(cfg, httpFactory, env, ai);
+    return new NutritionService(cfg, httpFactory, env, sessions, ai);
 });
 
 

--- a/FoodBot/Services/INutritionSessionService.cs
+++ b/FoodBot/Services/INutritionSessionService.cs
@@ -1,0 +1,11 @@
+using System;
+using FoodBot.Models;
+
+namespace FoodBot.Services
+{
+    public interface INutritionSessionService
+    {
+        NutritionSession Create(string imageDataUrl);
+        bool TryGet(Guid id, out NutritionSession session);
+    }
+}

--- a/FoodBot/Services/NutritionSessionService.cs
+++ b/FoodBot/Services/NutritionSessionService.cs
@@ -1,0 +1,37 @@
+using System;
+using FoodBot.Models;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace FoodBot.Services
+{
+    /// <summary>
+    /// Manages nutrition analysis sessions using a cache store.
+    /// Allows switching to persistent storage in the future.
+    /// </summary>
+    public class NutritionSessionService : INutritionSessionService
+    {
+        private readonly IMemoryCache _cache;
+        private readonly MemoryCacheEntryOptions _options;
+
+        public NutritionSessionService(IMemoryCache cache)
+        {
+            _cache = cache;
+            _options = new MemoryCacheEntryOptions
+            {
+                SlidingExpiration = TimeSpan.FromHours(1)
+            };
+        }
+
+        public NutritionSession Create(string imageDataUrl)
+        {
+            var session = new NutritionSession { ImageDataUrl = imageDataUrl };
+            _cache.Set(session.Id, session, _options);
+            return session;
+        }
+
+        public bool TryGet(Guid id, out NutritionSession session)
+        {
+            return _cache.TryGetValue(id, out session!);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add NutritionSession model and service to manage session data in one place
- refactor NutritionService to use session service instead of ConcurrentDictionary
- wire up session service via DI with memory cache

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f80d1f048331adf4eeb0ba7db8f0