### PR TITLE
Add ClaimsPrincipal chat id extension

### DIFF
--- a/FoodBot/Controllers/ClaimsPrincipalExtensions.cs
+++ b/FoodBot/Controllers/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Security.Claims;
+
+namespace FoodBot.Controllers;
+
+public static class ClaimsPrincipalExtensions
+{
+    public static long GetChatId(this ClaimsPrincipal user) =>
+        long.TryParse(user.FindFirstValue("chat_id"), out var id)
+            ? id
+            : throw new UnauthorizedAccessException();
+}

--- a/FoodBot/Controllers/ProfileController.cs
+++ b/FoodBot/Controllers/ProfileController.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using FoodBot.Data;
@@ -18,17 +17,14 @@ public sealed class ProfileController : ControllerBase
         _cards = cards;
     }
 
-    private long GetChatId() =>
-        long.TryParse(User.FindFirstValue("chat_id"), out var id) ? id : throw new UnauthorizedAccessException();
-
     [HttpGet]
     public async Task<ActionResult<PersonalCard?>> Get(CancellationToken ct)
     {
-        var card = await _cards.GetAsync(GetChatId(), ct);
+        var card = await _cards.GetAsync(User.GetChatId(), ct);
         return Ok(card);
     }
 
     [HttpPost]
     public Task<PersonalCard> Save([FromBody] PersonalCard card, CancellationToken ct)
-        => _cards.UpsertAsync(GetChatId(), card, ct);
+        => _cards.UpsertAsync(User.GetChatId(), card, ct);
 }

--- a/FoodBot/Controllers/StatsController.cs
+++ b/FoodBot/Controllers/StatsController.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -20,19 +19,16 @@ public sealed class StatsController : ControllerBase
         _stats = stats;
     }
 
-    private long GetChatId() =>
-        long.TryParse(User.FindFirstValue("chat_id"), out var id) ? id : throw new UnauthorizedAccessException();
-
     [HttpGet("summary")]
     public Task<StatsSummary> Summary([FromQuery] int days = 1, CancellationToken ct = default)
     {
         days = Math.Clamp(days, 1, 30);
-        return _stats.GetSummaryAsync(GetChatId(), days, ct);
+        return _stats.GetSummaryAsync(User.GetChatId(), days, ct);
     }
 
     [HttpGet("daily")]
     public Task<List<DailyTotals>> Daily([FromQuery] DateTime from, [FromQuery] DateTime to, CancellationToken ct = default)
     {
-        return _stats.GetDailyTotalsAsync(GetChatId(), from, to, ct);
+        return _stats.GetDailyTotalsAsync(User.GetChatId(), from, to, ct);
     }
 }


### PR DESCRIPTION
## Summary
- add ClaimsPrincipal extension to fetch chat ID
- reuse extension in Meals, Stats, Profile and Analysis controllers

## Testing
- `dotnet test FoodBot/FoodBot.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b802697f7883318d924242b4532664