### PR TITLE
Use EF async methods in MealService

### DIFF
--- a/FoodBot.Tests/FoodBot.Tests.csproj
+++ b/FoodBot.Tests/FoodBot.Tests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../FoodBot/FoodBot.csproj" />


### PR DESCRIPTION
## Summary
- make MealService methods fully async using EF Core operations
- support async repository access in unit tests with EF Core InMemory provider

## Testing
- `dotnet test FoodBot/FoodBot.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b8041a96448331af0205beb18f5709