### PR TITLE
Fix FoodDb namespace to FoodBot.Data

### DIFF
--- a/FoodBot/Data/FoodDb.cs
+++ b/FoodBot/Data/FoodDb.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
-namespace FoodBot.Services
+namespace FoodBot.Data
 {
     /// <summary>
     /// Загружает foods.json, нормализует единицы измерения:

--- a/FoodBot/Services/FoodMatcher.cs
+++ b/FoodBot/Services/FoodMatcher.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text;
 using System.Text.RegularExpressions;
 using FoodBot.Models;
+using FoodBot.Data;
 
 namespace FoodBot.Services;
 


### PR DESCRIPTION
## Summary
- align FoodDb with Data namespace
- update FoodMatcher to reference FoodDb in Data namespace

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b808d7c204833180be529a2bb5c475