### PR TITLE
Fix UTC offset formatting in ReportDataLoader

### DIFF
--- a/FoodBot/Services/ReportDataLoader.cs
+++ b/FoodBot/Services/ReportDataLoader.cs
@@ -110,7 +110,7 @@ public sealed class ReportDataLoader
             .ToList();
 
         var utcOffset = tz.GetUtcOffset(nowLocal.DateTime);
-        var utcOffsetStr = utcOffset.ToString(@"hh\\:mm");
+        var utcOffsetStr = utcOffset.ToString("hh\\:mm");
         var nowLocalStr = nowLocal.ToString("yyyy-MM-dd HH:mm");
         var nowLocalHourStr = nowLocal.ToString("HH");
         var nowLocalDateStr = nowLocal.ToString("yyyy-MM-dd");


### PR DESCRIPTION
## Summary
- correct TimeSpan formatting string in ReportDataLoader so `HH:mm` is produced without exceptions

## Testing
- `dotnet test FoodBot/FoodBot.sln`
- `dotnet run --project Sandbox/Sandbox.csproj` *(temporary project to call `ReportDataLoader.LoadAsync`)*

------
https://chatgpt.com/codex/tasks/task_e_68b87f265efc8331b77c1bb1b16561b0