### PR TITLE
feat: add pdf report download

### DIFF
--- a/mobile/calorie-counter/src/app/pages/stats/stats.page.html
+++ b/mobile/calorie-counter/src/app/pages/stats/stats.page.html
@@ -21,6 +21,8 @@
       <mat-button-toggle value="chart">График</mat-button-toggle>
       <mat-button-toggle value="table">Таблица</mat-button-toggle>
     </mat-button-toggle-group>
+
+    <button mat-raised-button (click)="downloadPdf()">PDF отчёт</button>
   </div>
 
   <!-- Легенда по периоду -->

--- a/mobile/calorie-counter/src/app/services/stats.service.ts
+++ b/mobile/calorie-counter/src/app/services/stats.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { FoodBotAuthLinkService } from './foodbot-auth-link.service';
 
@@ -36,6 +36,17 @@ export class StatsService {
       .set('from', this.formatDate(from))
       .set('to', this.formatDate(to));
     return this.http.get<DayStats[]>(`${this.baseUrl}/api/stats/daily`, { params });
+  }
+
+  downloadPdf(from: Date, to: Date): Observable<HttpResponse<Blob>> {
+    const params = new HttpParams()
+      .set('from', this.formatDate(from))
+      .set('to', this.formatDate(to));
+    return this.http.get(`${this.baseUrl}/api/report/pdf`, {
+      params,
+      responseType: 'blob',
+      observe: 'response',
+    });
   }
 
   private formatDate(d: Date): string {


### PR DESCRIPTION
## Summary
- add StatsService.downloadPdf to request PdfReportController
- add downloadPdf button in stats page to generate report for current period

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b937a8901c833184e21c3ff9290063