### PR TITLE
Add Russian language support to PDF reports

### DIFF
--- a/FoodBot.Tests/PdfReportServiceTests.cs
+++ b/FoodBot.Tests/PdfReportServiceTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FoodBot.Data;
+using FoodBot.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+public class PdfReportServiceTests
+{
+    [Fact]
+    public async Task BuildAsync_GeneratesPdfWithRussianCharacters()
+    {
+        var options = new DbContextOptionsBuilder<BotDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        using var ctx = new BotDbContext(options);
+        ctx.PersonalCards.Add(new PersonalCard
+        {
+            ChatId = 1,
+            Name = "Иван Иванов",
+            BirthYear = 1990,
+            DietGoals = "Сброс веса",
+            MedicalRestrictions = "Нет"
+        });
+        ctx.Meals.Add(new MealEntry
+        {
+            Id = 1,
+            ChatId = 1,
+            UserId = 1,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            FileId = "file",
+            DishName = "Борщ"
+        });
+        await ctx.SaveChangesAsync();
+
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["PdfReport:LaTeXPath"] = "pdflatex"
+            })
+            .Build();
+
+        var service = new PdfReportService(ctx, cfg);
+        var (stream, fileName) = await service.BuildAsync(1, DateTime.UtcNow.AddDays(-1), DateTime.UtcNow);
+
+        Assert.False(string.IsNullOrEmpty(fileName));
+        Assert.True(stream.Length > 0);
+    }
+}

--- a/FoodBot/Services/PdfReportService.cs
+++ b/FoodBot/Services/PdfReportService.cs
@@ -50,6 +50,8 @@ public sealed class PdfReportService
         var sb = new StringBuilder();
         sb.AppendLine("\\documentclass{article}");
         sb.AppendLine("\\usepackage[utf8]{inputenc}");
+        sb.AppendLine("\\usepackage[T2A]{fontenc}");
+        sb.AppendLine("\\usepackage[russian]{babel}");
         sb.AppendLine("\\usepackage{graphicx}");
         sb.AppendLine("\\begin{document}");
         sb.AppendLine("\\section*{Отчёт о питании}");


### PR DESCRIPTION
## Summary
- enable LaTeX T2A encoding and Russian babel package for PDF report generation
- add test ensuring PDF report builds with Russian characters

## Testing
- `dotnet build FoodBot/FoodBot.sln`
- `dotnet test FoodBot/FoodBot.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68b9429db8dc83318f4ddc88f46d79fe