### PR TITLE
Use xelatex with Unicode font for analysis PDFs

### DIFF
--- a/FoodBot/Services/AnalysisPdfService.cs
+++ b/FoodBot/Services/AnalysisPdfService.cs
@@ -12,11 +12,13 @@ public sealed class AnalysisPdfService
 {
     private readonly string _pandocPath;
     private readonly string _pandocWorkingDir;
+    private readonly string _pandocFont;
 
     public AnalysisPdfService(IConfiguration cfg)
     {
         _pandocPath = cfg["PandocPath"] ?? "pandoc";
         _pandocWorkingDir = cfg["PandocWorkingDirectory"] ?? Directory.GetCurrentDirectory();
+        _pandocFont = cfg["PandocMainFont"] ?? "DejaVu Sans";
     }
 
     public async Task<(MemoryStream Stream, string FileName)> BuildAsync(string baseName, string markdown, CancellationToken ct = default)
@@ -29,7 +31,7 @@ public sealed class AnalysisPdfService
         var psi = new ProcessStartInfo
         {
             FileName = _pandocPath,
-            Arguments = $"\"{mdPath}\" -o \"{pdfPath}\" --pdf-engine=lualatex",
+            Arguments = $"\"{mdPath}\" -o \"{pdfPath}\" --pdf-engine=xelatex -V mainfont=\"{_pandocFont}\"",
             WorkingDirectory = _pandocWorkingDir,
             RedirectStandardError = true,
             RedirectStandardOutput = true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-"# CalorieJournal" 
+# CalorieJournal
+
+## Configuration
+
+The application uses [Pandoc](https://pandoc.org/) to render PDF reports.
+The following configuration keys can be provided (e.g., via environment
+variables or `appsettings.json`):
+
+| Key | Description | Default |
+| --- | --- | --- |
+| `PandocPath` | Path to the `pandoc` executable | `pandoc` |
+| `PandocWorkingDirectory` | Working directory for Pandoc | current directory |
+| `PandocMainFont` | Font used when generating PDFs | `DejaVu Sans` |
+
+`PandocMainFont` defaults to **DejaVu Sans**, a Unicode font that supports
+Cyrillic characters.


### PR DESCRIPTION
## Summary
- render analysis PDFs with xelatex and configurable Unicode font
- document Pandoc-related configuration options including default font

## Testing
- `fc-list | head`
- `pdftotext sample.pdf -`
- `~/.dotnet/dotnet test FoodBot/FoodBot.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b97b7960d8833186025b396a3de72b