### PR TITLE
Queue analysis PDF jobs and worker

### DIFF
--- a/FoodBot/Controllers/AnalysisController.cs
+++ b/FoodBot/Controllers/AnalysisController.cs
@@ -1,7 +1,9 @@
 using System.Threading;
 using System.Threading.Tasks;
+using FoodBot.Data;
 using FoodBot.Models;
 using FoodBot.Services;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -13,12 +15,12 @@ namespace FoodBot.Controllers;
 public sealed class AnalysisController : ControllerBase
 {
     private readonly DietAnalysisService _service;
-    private readonly AnalysisPdfService _pdf;
+    private readonly BotDbContext _db;
 
-    public AnalysisController(DietAnalysisService service, AnalysisPdfService pdf)
+    public AnalysisController(DietAnalysisService service, BotDbContext db)
     {
         _service = service;
-        _pdf = pdf;
+        _db = db;
     }
 
     // История
@@ -84,8 +86,32 @@ public sealed class AnalysisController : ControllerBase
         if (r == null) return NotFound();
         if (r.IsProcessing || string.IsNullOrEmpty(r.Markdown)) return BadRequest();
 
-        var (stream, fileName) = await _pdf.BuildAsync(r.Name ?? $"report_{id}", r.Markdown, ct);
-        stream.Position = 0;
+        var job = new AnalysisPdfJob
+        {
+            ChatId = chatId,
+            ReportId = id,
+            Status = AnalysisPdfJobStatus.Queued,
+            CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+        _db.AnalysisPdfJobs.Add(job);
+        await _db.SaveChangesAsync(ct);
+
+        return Accepted(new { id = job.Id, status = job.Status.ToString().ToLower() });
+    }
+
+    [HttpGet("pdf-jobs/{id:long}")]
+    public async Task<IActionResult> GetPdfJob([FromRoute] long id, CancellationToken ct)
+    {
+        var chatId = User.GetChatId();
+        var job = await _db.AnalysisPdfJobs.AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == id && x.ChatId == chatId, ct);
+        if (job == null) return NotFound();
+
+        if (job.Status != AnalysisPdfJobStatus.Done || string.IsNullOrEmpty(job.FilePath) || !System.IO.File.Exists(job.FilePath))
+            return Accepted(new { status = job.Status.ToString().ToLower() });
+
+        var stream = System.IO.File.OpenRead(job.FilePath);
+        var fileName = System.IO.Path.GetFileName(job.FilePath);
         return File(stream, "application/pdf", fileName);
     }
 

--- a/FoodBot/Data/AnalysisPdfJob.cs
+++ b/FoodBot/Data/AnalysisPdfJob.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace FoodBot.Data;
+
+public enum AnalysisPdfJobStatus
+{
+    Queued = 0,
+    Processing = 1,
+    Done = 2,
+    Failed = 3
+}
+
+public class AnalysisPdfJob
+{
+    public long Id { get; set; }
+    public long ChatId { get; set; }
+    public long ReportId { get; set; }
+    public AnalysisPdfJobStatus Status { get; set; }
+    public DateTimeOffset CreatedAtUtc { get; set; }
+    public DateTimeOffset? FinishedAtUtc { get; set; }
+    public string? FilePath { get; set; }
+}

--- a/FoodBot/Data/BotDbContext.cs
+++ b/FoodBot/Data/BotDbContext.cs
@@ -14,6 +14,7 @@ public class BotDbContext : DbContext
     public DbSet<AppStartCode> StartCodes => Set<AppStartCode>();
     public DbSet<PersonalCard> PersonalCards => Set<PersonalCard>();
     public DbSet<AnalysisReport1> AnalysisReports2 => Set<AnalysisReport1>();
+    public DbSet<AnalysisPdfJob> AnalysisPdfJobs => Set<AnalysisPdfJob>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -42,6 +43,9 @@ public class BotDbContext : DbContext
             .Property(x => x.ChatId)
             .ValueGeneratedNever();
 
-       
+        modelBuilder.Entity<AnalysisPdfJob>()
+            .HasIndex(x => new { x.Status, x.CreatedAtUtc });
+
+
     }
 }

--- a/FoodBot/Extensions/BotExtensions.cs
+++ b/FoodBot/Extensions/BotExtensions.cs
@@ -69,6 +69,7 @@ public static class BotExtensions
         services.AddScoped<IAppAuthService, AppAuthService>();
         services.AddHostedService<AnalysisQueueWorker>();
         services.AddHostedService<PhotoQueueWorker>();
+        services.AddHostedService<AnalysisPdfJobWorker>();
 
         services
             .AddControllers()

--- a/FoodBot/Migrations/20250905000000_analysispdfjob.Designer.cs
+++ b/FoodBot/Migrations/20250905000000_analysispdfjob.Designer.cs
@@ -4,6 +4,7 @@ using FoodBot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FoodBot.Migrations
 {
     [DbContext(typeof(BotDbContext))]
-    partial class BotDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250905000000_analysispdfjob")]
+    partial class analysispdfjob
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FoodBot/Migrations/20250905000000_analysispdfjob.cs
+++ b/FoodBot/Migrations/20250905000000_analysispdfjob.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FoodBot.Migrations
+{
+    /// <inheritdoc />
+    public partial class analysispdfjob : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AnalysisPdfJobs",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ChatId = table.Column<long>(type: "bigint", nullable: false),
+                    ReportId = table.Column<long>(type: "bigint", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    CreatedAtUtc = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    FinishedAtUtc = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    FilePath = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AnalysisPdfJobs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AnalysisPdfJobs_Status_CreatedAtUtc",
+                table: "AnalysisPdfJobs",
+                columns: new[] { "Status", "CreatedAtUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AnalysisPdfJobs");
+        }
+    }
+}

--- a/FoodBot/Services/AnalysisPdfJobWorker.cs
+++ b/FoodBot/Services/AnalysisPdfJobWorker.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FoodBot.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.InputFiles;
+
+namespace FoodBot.Services;
+
+public sealed class AnalysisPdfJobWorker : BackgroundService
+{
+    private readonly ILogger<AnalysisPdfJobWorker> _log;
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public AnalysisPdfJobWorker(ILogger<AnalysisPdfJobWorker> log, IServiceScopeFactory scopeFactory)
+    {
+        _log = log;
+        _scopeFactory = scopeFactory;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<BotDbContext>();
+                var pdf = scope.ServiceProvider.GetRequiredService<AnalysisPdfService>();
+                var bot = scope.ServiceProvider.GetRequiredService<TelegramBotClient>();
+
+                var job = await db.AnalysisPdfJobs
+                    .Where(x => x.Status == AnalysisPdfJobStatus.Queued)
+                    .OrderBy(x => x.CreatedAtUtc)
+                    .FirstOrDefaultAsync(stoppingToken);
+
+                if (job == null)
+                {
+                    await Task.Delay(2000, stoppingToken);
+                    continue;
+                }
+
+                job.Status = AnalysisPdfJobStatus.Processing;
+                await db.SaveChangesAsync(stoppingToken);
+
+                var report = await db.AnalysisReports2
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(r => r.Id == job.ReportId && r.ChatId == job.ChatId, stoppingToken);
+                if (report == null || string.IsNullOrEmpty(report.Markdown))
+                {
+                    job.Status = AnalysisPdfJobStatus.Failed;
+                    job.FinishedAtUtc = DateTimeOffset.UtcNow;
+                    await db.SaveChangesAsync(stoppingToken);
+                    continue;
+                }
+
+                var (stream, fileName) = await pdf.BuildAsync(report.Name ?? $"report_{report.Id}", report.Markdown, stoppingToken);
+                stream.Position = 0;
+
+                var dir = Path.Combine(AppContext.BaseDirectory, "pdf-jobs");
+                Directory.CreateDirectory(dir);
+                var path = Path.Combine(dir, $"{job.Id}_{fileName}");
+                using (var fs = File.Create(path))
+                {
+                    await stream.CopyToAsync(fs, stoppingToken);
+                }
+
+                job.FilePath = path;
+                job.Status = AnalysisPdfJobStatus.Done;
+                job.FinishedAtUtc = DateTimeOffset.UtcNow;
+                await db.SaveChangesAsync(stoppingToken);
+
+                stream.Position = 0;
+                await bot.SendDocument(job.ChatId, InputFile.FromStream(stream, fileName), cancellationToken: stoppingToken);
+            }
+            catch (TaskCanceledException) { }
+            catch (Exception ex)
+            {
+                _log.LogError(ex, "AnalysisPdfJobWorker iteration failed");
+                await Task.Delay(2000, stoppingToken);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `AnalysisPdfJob` entity and EF migration
- queue PDF generation in `AnalysisController` and provide status endpoint
- implement background `AnalysisPdfJobWorker` to build PDFs and send via Telegram

## Testing
- `dotnet build FoodBot/FoodBot.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baacd479fc833198f1a76cdd2b4f0d