### PR TITLE
Capture LaTeX process output

### DIFF
--- a/FoodBot.Tests/PdfReportServiceTests.cs
+++ b/FoodBot.Tests/PdfReportServiceTests.cs
@@ -6,6 +6,7 @@ using FoodBot.Data;
 using FoodBot.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 public class PdfReportServiceTests
@@ -43,7 +44,9 @@ public class PdfReportServiceTests
             })
             .Build();
 
-        var service = new PdfReportService(ctx, cfg);
+        using var loggerFactory = LoggerFactory.Create(b => { });
+        var logger = loggerFactory.CreateLogger<PdfReportService>();
+        var service = new PdfReportService(ctx, cfg, logger);
         var (stream, fileName) = await service.BuildAsync(1, DateTime.UtcNow.AddDays(-1), DateTime.UtcNow);
 
         Assert.False(string.IsNullOrEmpty(fileName));


### PR DESCRIPTION
## Summary
- log and throw pdflatex stdout/stderr when compilation fails
- inject logger into PdfReportService and adapt tests

## Testing
- `dotnet test FoodBot.Tests/FoodBot.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68babcb8a4dc833194a34c527cbf8d8f