### PR TITLE
Fix StatsService injectable decorator placement

### DIFF
--- a/mobile/calorie-counter/src/app/services/stats.service.ts
+++ b/mobile/calorie-counter/src/app/services/stats.service.ts
@@ -21,11 +21,11 @@ export interface DayStats {
   totals: MacroTotals;
 }
 
-@Injectable({ providedIn: 'root' })
 export interface PdfJobResponse {
   jobId: string;
 }
 
+@Injectable({ providedIn: 'root' })
 export class StatsService {
   constructor(private http: HttpClient, private auth: FoodBotAuthLinkService) {}
   private get baseUrl(): string { return this.auth.apiBaseUrl; }


### PR DESCRIPTION
## Summary
- fix StatsService decorator placement by moving `@Injectable` onto service class

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68bac95305508331abc53fd843f6511a