### PR TITLE
Fix PDF job endpoint to accept POST

### DIFF
--- a/FoodBot/Controllers/AnalysisController.cs
+++ b/FoodBot/Controllers/AnalysisController.cs
@@ -79,7 +79,7 @@ public sealed class AnalysisController : ControllerBase
         });
     }
 
-    [HttpGet("{id:long}/pdf")]
+    [HttpPost("{id:long}/pdf")]
     public async Task<IActionResult> GetPdf([FromRoute] long id, CancellationToken ct)
     {
         var chatId = User.GetChatId();


### PR DESCRIPTION
## Summary
- use POST for /api/analysis/{id}/pdf so clients can start a PDF job

## Testing
- `dotnet test FoodBot/FoodBot.sln` *(fails: command not found: dotnet; tried installing but package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bace7e8828833184c3e72dfc2d0b95