### PR TITLE
Use POST for PDF report endpoint

### DIFF
--- a/FoodBot/Controllers/PdfReportController.cs
+++ b/FoodBot/Controllers/PdfReportController.cs
@@ -18,8 +18,8 @@ public sealed class PdfReportController : ControllerBase
         _db = db;
     }
 
-    [HttpGet("pdf")]
-    public async Task<IActionResult> Get(
+    [HttpPost("pdf")]
+    public async Task<IActionResult> Post(
         [FromQuery] DateTime from,
         [FromQuery] DateTime to,
         CancellationToken ct = default)


### PR DESCRIPTION
## Summary
- switch `/api/report/pdf` route to POST so clients can generate period report with a POST request

## Testing
- `dotnet test FoodBot/FoodBot.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bad2cb50fc8331a78237d096e61bbe