### PR TITLE
feat: add auto and manual Telegram login tabs

### DIFF
--- a/mobile/calorie-counter/src/app/pages/auth/auth.page.html
+++ b/mobile/calorie-counter/src/app/pages/auth/auth.page.html
@@ -1,27 +1,46 @@
-﻿<mat-card>
-  <h2>Вход через Telegram</h2>
-  <p>1) Скопируй код и отправь его боту как команду <code>/start &lt;код&gt;</code> (или просто отправь код).</p>
+<mat-card>
+  <mat-tab-group>
+    <mat-tab label="Автоматически">
+      <h2>Вход через Telegram</h2>
+      <p>Нажмите кнопку, чтобы открыть бота и подтвердить вход.</p>
+      <div class="actions">
+        <button mat-raised-button color="primary" (click)="openBot()" [disabled]="!code">
+          <mat-icon>send</mat-icon> Открыть бота
+        </button>
+      </div>
+      <div class="pending" *ngIf="busy">
+        <mat-progress-spinner mode="indeterminate" diameter="28"></mat-progress-spinner>
+        <span>Ждём подтверждение…</span>
+      </div>
+      <p class="expires" *ngIf="expiresAt">Код действителен до: {{ expiresAt | date:'medium' }}</p>
+    </mat-tab>
+    <mat-tab label="Вручную">
+      <h2>Вход через Telegram вручную</h2>
+      <p>Если автоматический вход не сработал, выполните шаги вручную:</p>
+      <p>1) Скопируй код и отправь его боту как команду <code>/start &lt;код&gt;</code> (или просто отправь код).</p>
 
-  <div class="code-pill" *ngIf="code">{{ code }}</div>
-  <div class="actions">
-    <button mat-raised-button color="primary" (click)="copyCode()" [disabled]="!code">
-      <mat-icon>content_copy</mat-icon> Скопировать
-    </button>
-    <button mat-stroked-button color="primary" (click)="openBot()" [disabled]="!code">
-      <mat-icon>send</mat-icon> Открыть бота
-    </button>
-    <button mat-flat-button color="accent" (click)="refresh()" [disabled]="busy || !code">
-      <mat-icon>sync</mat-icon> Обновить статус
-    </button>
-    <button mat-button (click)="restart()" [disabled]="busy">
-      <mat-icon>autorenew</mat-icon> Запросить новый код
-    </button>
-  </div>
+      <div class="code-pill" *ngIf="code">{{ code }}</div>
+      <div class="actions">
+        <button mat-raised-button color="primary" (click)="copyCode()" [disabled]="!code">
+          <mat-icon>content_copy</mat-icon> Скопировать
+        </button>
+        <button mat-stroked-button color="primary" (click)="openBot()" [disabled]="!code">
+          <mat-icon>send</mat-icon> Открыть бота
+        </button>
+        <button mat-flat-button color="accent" (click)="refresh()" [disabled]="busy || !code">
+          <mat-icon>sync</mat-icon> Обновить статус
+        </button>
+        <button mat-button (click)="restart()" [disabled]="busy">
+          <mat-icon>autorenew</mat-icon> Запросить новый код
+        </button>
+      </div>
 
-  <div class="pending" *ngIf="busy">
-    <mat-progress-spinner mode="indeterminate" diameter="28"></mat-progress-spinner>
-    <span>Ждём подтверждение…</span>
-  </div>
+      <div class="pending" *ngIf="busy">
+        <mat-progress-spinner mode="indeterminate" diameter="28"></mat-progress-spinner>
+        <span>Ждём подтверждение…</span>
+      </div>
 
-  <p class="expires" *ngIf="expiresAt">Код действителен до: {{ expiresAt | date:'medium' }}</p>
+      <p class="expires" *ngIf="expiresAt">Код действителен до: {{ expiresAt | date:'medium' }}</p>
+    </mat-tab>
+  </mat-tab-group>
 </mat-card>

--- a/mobile/calorie-counter/src/app/pages/auth/auth.page.ts
+++ b/mobile/calorie-counter/src/app/pages/auth/auth.page.ts
@@ -7,12 +7,21 @@ import { MatSnackBar, MatSnackBarModule } from "@angular/material/snack-bar";
 import { Router } from "@angular/router";
 import { FoodBotAuthLinkService, ExchangeStartCodeResponse } from "../../services/foodbot-auth-link.service";
 import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
+import { MatTabsModule } from "@angular/material/tabs";
 import { showErrorAlert } from "../../utils/alerts";
 
 @Component({
   selector: "app-auth",
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule, MatSnackBarModule, MatProgressSpinnerModule],
+    imports: [
+      CommonModule,
+      MatCardModule,
+      MatButtonModule,
+      MatIconModule,
+      MatSnackBarModule,
+      MatProgressSpinnerModule,
+      MatTabsModule
+    ],
   templateUrl: "./auth.page.html",
   styleUrls: ["./auth.page.scss"]
 })


### PR DESCRIPTION
## Summary
- Split Telegram login into auto and manual tabs
- Add MatTabsModule to auth page

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68bad71793588331973654ef9db461b8