### PR TITLE
feat: build Angular app before dotnet build

### DIFF
--- a/FoodBot/FoodBot.csproj
+++ b/FoodBot/FoodBot.csproj
@@ -20,4 +20,10 @@
     <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="System.Net.Http.Json" Version="9.0.8" />
   </ItemGroup>
+
+  <Target Name="BuildClientApp" BeforeTargets="Build">
+    <RemoveDir Directories="$(ProjectDir)wwwroot" />
+    <Exec WorkingDirectory="../mobile/calorie-counter" Command="npm install" />
+    <Exec WorkingDirectory="../mobile/calorie-counter" Command="npm run build -- --output-path ../../FoodBot/wwwroot --configuration production" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
- install and build Angular client before .NET build
- clean wwwroot prior to copying new client assets

## Testing
- `dotnet build FoodBot/FoodBot.sln`
- `dotnet test FoodBot/FoodBot.sln` *(fails: System.ComponentModel.Win32Exception: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68badd2ea43c8331a3a5379b29dcf491