### PR TITLE
Fix Angular build output path to avoid browser subdirectory

### DIFF
--- a/FoodBot/FoodBot.csproj
+++ b/FoodBot/FoodBot.csproj
@@ -24,6 +24,6 @@
   <Target Name="BuildClientApp" BeforeTargets="Build">
     <RemoveDir Directories="$(ProjectDir)wwwroot" />
     <Exec WorkingDirectory="../mobile/calorie-counter" Command="npm install" />
-    <Exec WorkingDirectory="../mobile/calorie-counter" Command="npm run build -- --output-path ../../FoodBot/wwwroot --configuration production" />
+    <Exec WorkingDirectory="../mobile/calorie-counter" Command="npm run build -- --configuration production" />
   </Target>
 </Project>

--- a/mobile/calorie-counter/angular.json
+++ b/mobile/calorie-counter/angular.json
@@ -28,7 +28,10 @@
         "build": {
           "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist/calorie-counter",
+            "outputPath": {
+              "base": "dist/calorie-counter",
+              "browser": ""
+            },
             "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
@@ -50,6 +53,10 @@
           },
           "configurations": {
             "production": {
+              "outputPath": {
+                "base": "../../FoodBot/wwwroot",
+                "browser": ""
+              },
               "budgets": [
                 {
                   "type": "initial",


### PR DESCRIPTION
## Summary
- configure Angular build to emit files directly into FoodBot/wwwroot without nested `browser`
- simplify FoodBot build target to rely on Angular config

## Testing
- `npm install`
- `npm run build -- --configuration production`
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bae2ae5d7c8331800b2a9358c72223