### PR TITLE
fix: guard optional note property

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
@@ -89,7 +89,9 @@ export class HistoryDetailDialogComponent implements OnInit {
         this.snack.open('Уточнение отправлено', 'OK', { duration: 1500 });
         return;
       }
-      this.clarifyNote = r.note ?? this.clarifyNote;
+      if ('note' in r) {
+        this.clarifyNote = r.note ?? this.clarifyNote;
+      }
       const res = r as ClarifyResult;
       this.data.item.createdAtUtc = res.createdAtUtc;
       this.data.item.dishName = res.result.dish;


### PR DESCRIPTION
## Summary
- prevent TypeScript error by checking for optional `note` before use in history detail dialog

## Testing
- `npm run build`
- `npm test -- --watch=false` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1a0509f883318fd5fb05b1441508