### PR TITLE
feat: support safe-area insets

### DIFF
--- a/mobile/calorie-counter/src/index.html
+++ b/mobile/calorie-counter/src/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>HealthyMeals</title>
   <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet">
   <!-- Материальные иконки (для <mat-icon>) -->

--- a/mobile/calorie-counter/src/styles.scss
+++ b/mobile/calorie-counter/src/styles.scss
@@ -28,4 +28,6 @@ body {
   margin: 0;
   font-family: "Roboto", sans-serif;
   background: #f0f2f5;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
 }


### PR DESCRIPTION
## Summary
- use `viewport-fit=cover` in mobile meta tag
- add safe-area top and bottom padding

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc25dad6c8331a99b7a86cac3300d