### PR TITLE
Add Capacitor status bar plugin and disable overlay

### DIFF
--- a/mobile/calorie-counter/package-lock.json
+++ b/mobile/calorie-counter/package-lock.json
@@ -25,6 +25,7 @@
         "@capacitor/core": "^7.4.3",
         "@capacitor/filesystem": "^7.1.4",
         "@capacitor/preferences": "^7.0.2",
+        "@capacitor/status-bar": "^7.0.3",
         "@fontsource/material-icons": "^5.2.5",
         "@fontsource/material-icons-outlined": "^5.2.6",
         "@fontsource/material-icons-round": "^5.2.6",
@@ -1305,6 +1306,15 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@capacitor/preferences/-/preferences-7.0.2.tgz",
       "integrity": "sha512-JVCy0/oc6RsRencLOZ8rMqjNxAlHs7awPJU/MXqangsJ48oO2PnYGHfCvci6WgIJlqyC0QhvWZaO1BR1lVkHWQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor/status-bar": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-7.0.3.tgz",
+      "integrity": "sha512-JyRpVnKwHij9hgPWolF6PK+HT3e2HSPjN11/h2OmKxq8GAdPGARFLv+97eZl0pvuvm0Kka/LpiLb5whXISBg7Q==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"

--- a/mobile/calorie-counter/package.json
+++ b/mobile/calorie-counter/package.json
@@ -27,6 +27,7 @@
     "@capacitor/core": "^7.4.3",
     "@capacitor/filesystem": "^7.1.4",
     "@capacitor/preferences": "^7.0.2",
+    "@capacitor/status-bar": "^7.0.3",
     "@fontsource/material-icons": "^5.2.5",
     "@fontsource/material-icons-outlined": "^5.2.6",
     "@fontsource/material-icons-round": "^5.2.6",

--- a/mobile/calorie-counter/src/app/app.component.ts
+++ b/mobile/calorie-counter/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from "@angular/core";
+import { Component, ViewChild, OnInit } from "@angular/core";
 import { RouterOutlet, Router, NavigationEnd } from "@angular/router";
 import { filter } from 'rxjs/operators';
 import { MatToolbarModule } from "@angular/material/toolbar";
@@ -6,6 +6,7 @@ import { MatIconModule } from "@angular/material/icon";
 import { MatButtonModule } from "@angular/material/button";
 import { MatSidenavModule, MatSidenav } from "@angular/material/sidenav";
 import { SideMenuComponent } from "./components/side-menu/side-menu.component";
+import { StatusBar } from "@capacitor/status-bar";
 
 @Component({
   selector: "app-root",
@@ -14,7 +15,7 @@ import { SideMenuComponent } from "./components/side-menu/side-menu.component";
   templateUrl: "./app.component.html",
   styleUrls: ["./app.component.scss"],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'calorie-counter';
   @ViewChild('drawer') drawer!: MatSidenav;
 
@@ -26,5 +27,9 @@ export class AppComponent {
           this.drawer.close();
         }
       });
+  }
+
+  async ngOnInit() {
+    await StatusBar.setOverlaysWebView({ overlay: false });
   }
 }


### PR DESCRIPTION
## Summary
- add @capacitor/status-bar dependency
- disable status bar overlay on app init

## Testing
- `npx cap sync` *(fails: Could not find the web assets directory)*
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc35bd2a48331a3eab7274aad7603