### PR TITLE
Ensure Android WebView fits system windows

### DIFF
--- a/mobile/calorie-counter/android/app/src/main/res/layout/activity_main.xml
+++ b/mobile/calorie-counter/android/app/src/main/res/layout/activity_main.xml
@@ -4,9 +4,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".MainActivity">
 
     <WebView
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:fitsSystemWindows="true" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Summary
- Add `android:fitsSystemWindows="true"` to the Android `CoordinatorLayout` and nested `WebView` so content respects system windows

## Testing
- `npx ng test --watch=false` *(fails: Cannot find module '@capacitor/status-bar')*


------
https://chatgpt.com/codex/tasks/task_e_68bbc73c01e48331b4c6de6370af0eff