### PR TITLE
fix: update capacitor webDir

### DIFF
--- a/mobile/calorie-counter/capacitor.config.ts
+++ b/mobile/calorie-counter/capacitor.config.ts
@@ -3,7 +3,7 @@
 const config: CapacitorConfig = {
   appId: 'com.yourscriptor.calorie',
   appName: 'HealthyMeals',
-  webDir: 'dist/calorie-counter/browser',
+  webDir: '../../FoodBot/wwwroot',
   bundledWebRuntime: false,
   android: { allowMixedContent: true }
 };


### PR DESCRIPTION
## Summary
- point Capacitor's webDir to the built ASP.NET wwwroot folder

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bbca9de424833195229997ec591a5c