### PR TITLE
fix: align Android build tools with Gradle

### DIFF
--- a/mobile/calorie-counter/android/build.gradle
+++ b/mobile/calorie-counter/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.12.1'
+        classpath 'com.android.tools.build:gradle:8.1.2'
         classpath 'com.google.gms:google-services:4.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/mobile/calorie-counter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile/calorie-counter/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- use Android Gradle Plugin 8.1.2 instead of 8.12.x
- configure Gradle wrapper to 8.2.1 for compatibility

## Testing
- `./gradlew help` *(fails: Could not read script '.../capacitor-cordova-android-plugins/cordova.variables.gradle' as it does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcc8780f88331af963f0ede6ee5ad