### PR TITLE
feat: add bottom navigation

### DIFF
--- a/mobile/calorie-counter/src/app/app.component.html
+++ b/mobile/calorie-counter/src/app/app.component.html
@@ -13,5 +13,19 @@
     <div class="container">
       <router-outlet></router-outlet>
     </div>
+    <mat-toolbar color="primary" class="bottombar">
+      <a mat-button routerLink="/history" routerLinkActive="active">
+        <mat-icon>history</mat-icon>
+        <span>История</span>
+      </a>
+      <a mat-button routerLink="/add" routerLinkActive="active">
+        <mat-icon>add_a_photo</mat-icon>
+        <span>Добавить</span>
+      </a>
+      <a mat-button routerLink="/analysis" routerLinkActive="active">
+        <mat-icon>analytics</mat-icon>
+        <span>Анализ</span>
+      </a>
+    </mat-toolbar>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/mobile/calorie-counter/src/app/app.component.scss
+++ b/mobile/calorie-counter/src/app/app.component.scss
@@ -27,4 +27,26 @@
 .container {
   padding: 12px;
   margin-top: 64px;
+  margin-bottom: 56px;
+}
+
+.bottombar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+}
+
+.bottombar a {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: inherit;
+  text-decoration: none;
+}
+
+.bottombar a.active {
+  background: rgba(255, 255, 255, 0.1);
 }

--- a/mobile/calorie-counter/src/app/app.component.ts
+++ b/mobile/calorie-counter/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component, ViewChild, OnInit } from "@angular/core";
-import { RouterOutlet, Router, NavigationEnd } from "@angular/router";
+import { RouterOutlet, Router, NavigationEnd, RouterLink, RouterLinkActive } from "@angular/router";
 import { filter } from 'rxjs/operators';
 import { MatToolbarModule } from "@angular/material/toolbar";
 import { MatIconModule } from "@angular/material/icon";
@@ -11,7 +11,7 @@ import { StatusBar } from "@capacitor/status-bar";
 @Component({
   selector: "app-root",
   standalone: true,
-  imports: [RouterOutlet, MatToolbarModule, MatIconModule, MatButtonModule, MatSidenavModule, SideMenuComponent],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, MatToolbarModule, MatIconModule, MatButtonModule, MatSidenavModule, SideMenuComponent],
   templateUrl: "./app.component.html",
   styleUrls: ["./app.component.scss"],
 })


### PR DESCRIPTION
## Summary
- add bottom navigation bar with quick access to history, add photo, and analysis
- update component imports to support router links
- style new bottom toolbar and adjust content spacing

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1c9868008331a821b18cb88d9d39