### PR TITLE
fix(android): adjust bottom bar for nav overlap

### DIFF
--- a/mobile/calorie-counter/android/app/src/main/res/values/styles.xml
+++ b/mobile/calorie-counter/android/app/src/main/res/values/styles.xml
@@ -13,6 +13,10 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:background">@null</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/black</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:windowTranslucentNavigation">false</item>
     </style>
 
 

--- a/mobile/calorie-counter/src/app/app.component.scss
+++ b/mobile/calorie-counter/src/app/app.component.scss
@@ -27,7 +27,7 @@
 .container {
   padding: 12px;
   margin-top: 64px;
-  margin-bottom: 56px;
+  margin-bottom: calc(56px + env(safe-area-inset-bottom));
 }
 
 .bottombar {
@@ -37,6 +37,7 @@
   right: 0;
   display: flex;
   justify-content: space-around;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .bottombar a {


### PR DESCRIPTION
## Summary
- prevent bottom toolbar from sitting under the Android navigation bar
- force dark system bar colors for better contrast on Android

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68bd35717ae88331b6f9b7d2ece915ac