### PR TITLE
Disable edge-to-edge rendering on Android

### DIFF
--- a/mobile/calorie-counter/android/app/src/main/java/com/yourscriptor/calorie/MainActivity.java
+++ b/mobile/calorie-counter/android/app/src/main/java/com/yourscriptor/calorie/MainActivity.java
@@ -1,5 +1,13 @@
 package com.yourscriptor.calorie;
 
+import android.os.Bundle;
+import androidx.core.view.WindowCompat;
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    WindowCompat.setDecorFitsSystemWindows(getWindow(), true);
+  }
+}

--- a/mobile/calorie-counter/android/app/src/main/res/values/styles.xml
+++ b/mobile/calorie-counter/android/app/src/main/res/values/styles.xml
@@ -16,6 +16,7 @@
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/black</item>
         <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:windowTranslucentStatus">false</item>
         <item name="android:windowTranslucentNavigation">false</item>
     </style>
 


### PR DESCRIPTION
## Summary
- Ensure Android WebView respects system insets by calling `WindowCompat.setDecorFitsSystemWindows` in `MainActivity`
- Set status and navigation bar colors and disable translucent bars to avoid overlaying content

## Testing
- `CHROME_BIN=chromium-browser npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68be81491218833183f54d76f2725bc7