### PR TITLE
Configure Android system bars and safe area

### DIFF
--- a/mobile/calorie-counter/package-lock.json
+++ b/mobile/calorie-counter/package-lock.json
@@ -26,6 +26,7 @@
         "@capacitor/filesystem": "^7.1.4",
         "@capacitor/preferences": "^7.0.2",
         "@capacitor/status-bar": "^7.0.3",
+        "@capgo/capacitor-navigation-bar": "^7.1.28",
         "@fontsource/material-icons": "^5.2.5",
         "@fontsource/material-icons-outlined": "^5.2.6",
         "@fontsource/material-icons-round": "^5.2.6",
@@ -1325,6 +1326,15 @@
       "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
       "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
       "license": "ISC"
+    },
+    "node_modules/@capgo/capacitor-navigation-bar": {
+      "version": "7.1.28",
+      "resolved": "https://registry.npmjs.org/@capgo/capacitor-navigation-bar/-/capacitor-navigation-bar-7.1.28.tgz",
+      "integrity": "sha512-dOZBANeWBAEvjl1Qud73s21ZYT9/rivdOTWvEvu3+laLTPfi+bePI1lcw/1qPNWatcTWNs0axz3XVDkZ9ITcIA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",

--- a/mobile/calorie-counter/package.json
+++ b/mobile/calorie-counter/package.json
@@ -28,6 +28,7 @@
     "@capacitor/filesystem": "^7.1.4",
     "@capacitor/preferences": "^7.0.2",
     "@capacitor/status-bar": "^7.0.3",
+    "@capgo/capacitor-navigation-bar": "^7.1.28",
     "@fontsource/material-icons": "^5.2.5",
     "@fontsource/material-icons-outlined": "^5.2.6",
     "@fontsource/material-icons-round": "^5.2.6",

--- a/mobile/calorie-counter/src/main.ts
+++ b/mobile/calorie-counter/src/main.ts
@@ -1,4 +1,4 @@
-﻿import "zone.js";
+import "zone.js";
 import { bootstrapApplication } from "@angular/platform-browser";
 import { provideRouter } from "@angular/router";
 import { provideAnimations } from "@angular/platform-browser/animations";
@@ -6,6 +6,21 @@ import { provideHttpClient, withInterceptorsFromDi, HTTP_INTERCEPTORS } from "@a
 import { AppComponent } from "./app/app.component";
 import { routes } from "./app/routes";
 import { AuthInterceptor } from "./app/services/auth.interceptor";
+import { Capacitor } from "@capacitor/core";
+import { StatusBar } from "@capacitor/status-bar";
+
+// Configure Android status and navigation bars
+(async () => {
+  try {
+    if (Capacitor.getPlatform() === "android") {
+      await StatusBar.setOverlaysWebView({ overlay: false });
+      await StatusBar.setBackgroundColor({ color: "#000000" });
+      const { NavigationBar } = await import("@capgo/capacitor-navigation-bar");
+      await NavigationBar.setColor({ color: "#000000" });
+      await NavigationBar.setButtonStyle({ style: "LIGHT" });
+    }
+  } catch {}
+})();
 
 bootstrapApplication(AppComponent, {
   providers: [
@@ -15,3 +30,4 @@ bootstrapApplication(AppComponent, {
     { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true }
   ]
 }).catch(err => console.error(err));
+

--- a/mobile/calorie-counter/src/styles.scss
+++ b/mobile/calorie-counter/src/styles.scss
@@ -23,11 +23,13 @@
 @import "@fontsource/material-icons-round/index.css";
 @import "@fontsource/material-icons-sharp/index.css";
 
-html, body { height: 100%; }
+html, body, ion-app, ion-content { height: 100dvh; }
 body {
   margin: 0;
   font-family: "Roboto", sans-serif;
   background: #f0f2f5;
-  padding-top: env(safe-area-inset-top);
-  padding-bottom: env(safe-area-inset-bottom);
+}
+
+ion-content::part(scroll) {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }


### PR DESCRIPTION
## Summary
- disable status bar overlay and set Android system bar colors
- ensure content respects Android soft key area
- add navigation bar plugin dependency

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68be8e0e50ac833193e7a0567db4b8d5