### PR TITLE
Fix Android navigation bar plugin usage

### DIFF
--- a/mobile/calorie-counter/src/main.ts
+++ b/mobile/calorie-counter/src/main.ts
@@ -16,8 +16,7 @@ import { StatusBar } from "@capacitor/status-bar";
       await StatusBar.setOverlaysWebView({ overlay: false });
       await StatusBar.setBackgroundColor({ color: "#000000" });
       const { NavigationBar } = await import("@capgo/capacitor-navigation-bar");
-      await NavigationBar.setColor({ color: "#000000" });
-      await NavigationBar.setButtonStyle({ style: "LIGHT" });
+      await NavigationBar.setNavigationBarColor({ color: "#000000", darkButtons: false });
     }
   } catch {}
 })();


### PR DESCRIPTION
## Summary
- Replace deprecated NavigationBar methods with `setNavigationBarColor` and disable dark buttons for Android builds.

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm run build -- -c development`


------
https://chatgpt.com/codex/tasks/task_e_68be8f71db98833188fe7f737f256301