### PR TITLE
fix: show Android navigation bar

### DIFF
--- a/mobile/calorie-counter/android/app/src/main/java/com/yourscriptor/calorie/MainActivity.java
+++ b/mobile/calorie-counter/android/app/src/main/java/com/yourscriptor/calorie/MainActivity.java
@@ -8,6 +8,7 @@ public class MainActivity extends BridgeActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    setTheme(R.style.AppTheme_NoActionBar);
     WindowCompat.setDecorFitsSystemWindows(getWindow(), true);
   }
 }

--- a/mobile/calorie-counter/src/main.ts
+++ b/mobile/calorie-counter/src/main.ts
@@ -9,14 +9,12 @@ import { AuthInterceptor } from "./app/services/auth.interceptor";
 import { Capacitor } from "@capacitor/core";
 import { StatusBar } from "@capacitor/status-bar";
 
-// Configure Android status and navigation bars
+// Configure Android status bar
 (async () => {
   try {
     if (Capacitor.getPlatform() === "android") {
       await StatusBar.setOverlaysWebView({ overlay: false });
       await StatusBar.setBackgroundColor({ color: "#000000" });
-      const { NavigationBar } = await import("@capgo/capacitor-navigation-bar");
-      await NavigationBar.setNavigationBarColor({ color: "#000000", darkButtons: false });
     }
   } catch {}
 })();


### PR DESCRIPTION
## Summary
- apply main app theme after splash to color Android navigation bar
- streamline status bar setup in main bootstrap

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68be9c54ffdc83319c3a95103740dba0