### PR TITLE
Use Ionic safe area variable for bottom padding

### DIFF
--- a/mobile/calorie-counter/src/app/app.component.scss
+++ b/mobile/calorie-counter/src/app/app.component.scss
@@ -27,7 +27,7 @@
 .container {
   padding: 12px;
   margin-top: 64px;
-  margin-bottom: calc(56px + env(safe-area-inset-bottom));
+  margin-bottom: calc(56px + var(--ion-safe-area-bottom, env(safe-area-inset-bottom, 0px)));
 }
 
 .bottombar {
@@ -37,7 +37,7 @@
   right: 0;
   display: flex;
   justify-content: space-around;
-  padding-bottom: env(safe-area-inset-bottom);
+  padding-bottom: var(--ion-safe-area-bottom, env(safe-area-inset-bottom, 0px));
 }
 
 .bottombar a {

--- a/mobile/calorie-counter/src/styles.scss
+++ b/mobile/calorie-counter/src/styles.scss
@@ -31,5 +31,5 @@ body {
 }
 
 ion-content::part(scroll) {
-  padding-bottom: env(safe-area-inset-bottom, 0px);
+  padding-bottom: var(--ion-safe-area-bottom, env(safe-area-inset-bottom, 0px));
 }


### PR DESCRIPTION
## Summary
- use `--ion-safe-area-bottom` variable for global scroll padding
- adapt container and bottom bar spacing to framework safe area variable

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68bead94d9648331bc140997665d704d