### PR TITLE
Show status and navigation bar heights

### DIFF
--- a/mobile/calorie-counter/package-lock.json
+++ b/mobile/calorie-counter/package-lock.json
@@ -31,6 +31,7 @@
         "@fontsource/material-icons-outlined": "^5.2.6",
         "@fontsource/material-icons-round": "^5.2.6",
         "@fontsource/material-icons-sharp": "^5.2.6",
+        "capacitor-plugin-safe-area": "^4.0.0",
         "marked": "^12.0.2",
         "ngx-infinite-scroll": "^20.0.0",
         "rxjs": "~7.8.0",
@@ -5281,6 +5282,15 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/capacitor-plugin-safe-area": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/capacitor-plugin-safe-area/-/capacitor-plugin-safe-area-4.0.0.tgz",
+      "integrity": "sha512-5VHT4wG2TlwHtyy3zKrAjKwgJQgC3KeMfRW1bc8abTETLYNLxb85zvfpA0QFE59BxbtYHD57GvXKJuUPgEHl3g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
     },
     "node_modules/chalk": {
       "version": "5.6.0",

--- a/mobile/calorie-counter/package.json
+++ b/mobile/calorie-counter/package.json
@@ -33,6 +33,7 @@
     "@fontsource/material-icons-outlined": "^5.2.6",
     "@fontsource/material-icons-round": "^5.2.6",
     "@fontsource/material-icons-sharp": "^5.2.6",
+    "capacitor-plugin-safe-area": "^4.0.0",
     "marked": "^12.0.2",
     "ngx-infinite-scroll": "^20.0.0",
     "rxjs": "~7.8.0",

--- a/mobile/calorie-counter/src/app/app.component.ts
+++ b/mobile/calorie-counter/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, OnInit } from "@angular/core";
+import { Component, ViewChild, OnInit, AfterViewInit } from "@angular/core";
 import { RouterOutlet, Router, NavigationEnd, RouterLink, RouterLinkActive } from "@angular/router";
 import { filter } from 'rxjs/operators';
 import { MatToolbarModule } from "@angular/material/toolbar";
@@ -7,6 +7,7 @@ import { MatButtonModule } from "@angular/material/button";
 import { MatSidenavModule, MatSidenav } from "@angular/material/sidenav";
 import { SideMenuComponent } from "./components/side-menu/side-menu.component";
 import { StatusBar } from "@capacitor/status-bar";
+import { SafeArea } from 'capacitor-plugin-safe-area';
 
 @Component({
   selector: "app-root",
@@ -15,7 +16,7 @@ import { StatusBar } from "@capacitor/status-bar";
   templateUrl: "./app.component.html",
   styleUrls: ["./app.component.scss"],
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnInit, AfterViewInit {
   title = 'calorie-counter';
   @ViewChild('drawer') drawer!: MatSidenav;
 
@@ -31,5 +32,11 @@ export class AppComponent implements OnInit {
 
   async ngOnInit() {
     await StatusBar.setOverlaysWebView({ overlay: false });
+  }
+
+  async ngAfterViewInit() {
+    const { insets } = await SafeArea.getSafeAreaInsets();
+    const { statusBarHeight } = await SafeArea.getStatusBarHeight();
+    alert(`status bar height = ${statusBarHeight}px, navigation bar height = ${insets.bottom}px`);
   }
 }


### PR DESCRIPTION
## Summary
- Use SafeArea plugin to calculate accurate status and navigation bar heights

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68bec3af54848331be002b2c0a8a4a21