### PR TITLE
Apply safe area insets for Android layout

### DIFF
--- a/mobile/calorie-counter/src/app/app.component.scss
+++ b/mobile/calorie-counter/src/app/app.component.scss
@@ -22,11 +22,12 @@
   left: 0;
   right: 0;
   z-index: 1000;
+  padding-top: var(--ion-safe-area-top, env(safe-area-inset-top, 0px));
 }
 
 .container {
   padding: 12px;
-  margin-top: 64px;
+  margin-top: calc(64px + var(--ion-safe-area-top, env(safe-area-inset-top, 0px)));
   margin-bottom: calc(56px + var(--ion-safe-area-bottom, env(safe-area-inset-bottom, 0px)));
 }
 

--- a/mobile/calorie-counter/src/app/app.component.spec.ts
+++ b/mobile/calorie-counter/src/app/app.component.spec.ts
@@ -25,6 +25,6 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, calorie-counter');
+    expect(compiled.querySelector('.topbar span')?.textContent).toContain('HealthyMeals');
   });
 });

--- a/mobile/calorie-counter/src/app/app.component.ts
+++ b/mobile/calorie-counter/src/app/app.component.ts
@@ -37,6 +37,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   async ngAfterViewInit() {
     const { insets } = await SafeArea.getSafeAreaInsets();
     const { statusBarHeight } = await SafeArea.getStatusBarHeight();
-    alert(`status bar height = ${statusBarHeight}px, navigation bar height = ${insets.bottom}px`);
+    document.documentElement.style.setProperty('--ion-safe-area-top', `${statusBarHeight}px`);
+    document.documentElement.style.setProperty('--ion-safe-area-bottom', `${insets.bottom}px`);
   }
 }

--- a/mobile/calorie-counter/src/capacitor-plugin-safe-area.d.ts
+++ b/mobile/calorie-counter/src/capacitor-plugin-safe-area.d.ts
@@ -1,0 +1,3 @@
+declare module 'capacitor-plugin-safe-area' {
+  export const SafeArea: any;
+}


### PR DESCRIPTION
## Summary
- set `--ion-safe-area-top` and `--ion-safe-area-bottom` from Capacitor SafeArea API
- adjust toolbar and container spacing to respect safe-area insets
- update unit test and add typings for SafeArea plugin

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68beef42e0b48331a80475fd460ba459