### PR TITLE
Fix Android overscroll and status bar styling

### DIFF
--- a/mobile/calorie-counter/src/app/app.component.scss
+++ b/mobile/calorie-counter/src/app/app.component.scss
@@ -14,6 +14,8 @@
 .app-content {
   display: flex;
   flex-direction: column;
+  height: 100dvh;
+  overflow: hidden;
 }
 
 .topbar {
@@ -26,6 +28,9 @@
 }
 
 .container {
+  flex: 1;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 12px;
   margin-top: calc(64px + var(--ion-safe-area-top, env(safe-area-inset-top, 0px)));
   margin-bottom: calc(56px + var(--ion-safe-area-bottom, env(safe-area-inset-bottom, 0px)));

--- a/mobile/calorie-counter/src/app/app.component.ts
+++ b/mobile/calorie-counter/src/app/app.component.ts
@@ -35,6 +35,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   async ngOnInit() {
     if (Capacitor.getPlatform() !== 'web') {
       await StatusBar.setOverlaysWebView({ overlay: false });
+      await StatusBar.setBackgroundColor({ color: '#ffffff' });
       await StatusBar.setStyle({ style: StatusBarStyle.Dark });
       await NavigationBar.setNavigationBarColor({ color: '#ffffff', darkButtons: true });
     }

--- a/mobile/calorie-counter/src/styles.scss
+++ b/mobile/calorie-counter/src/styles.scss
@@ -24,6 +24,12 @@
 @import "@fontsource/material-icons-sharp/index.css";
 
 html, body, ion-app, ion-content { height: 100dvh; }
+
+html, body {
+  overscroll-behavior: none;
+  overflow: hidden;
+}
+
 body {
   margin: 0;
   font-family: "Roboto", sans-serif;


### PR DESCRIPTION
## Summary
- prevent toolbar icons from moving during overscroll by confining scroll area
- ensure Android status bar has white background with dark icons

## Testing
- `npm test` *(fails: Could not resolve "capacitor-plugin-safe-area")*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68befcd050c08331b19082aa56765f67