### PR TITLE
Fix Android status bar style and spacing

### DIFF
--- a/mobile/calorie-counter/src/app/app.component.ts
+++ b/mobile/calorie-counter/src/app/app.component.ts
@@ -6,7 +6,6 @@ import { MatIconModule } from "@angular/material/icon";
 import { MatButtonModule } from "@angular/material/button";
 import { MatSidenavModule, MatSidenav } from "@angular/material/sidenav";
 import { SideMenuComponent } from "./components/side-menu/side-menu.component";
-import { StatusBar, Style as StatusBarStyle } from "@capacitor/status-bar";
 import { NavigationBar } from '@capgo/capacitor-navigation-bar';
 import { Capacitor } from '@capacitor/core';
 import { SafeArea } from 'capacitor-plugin-safe-area';
@@ -34,9 +33,6 @@ export class AppComponent implements OnInit, AfterViewInit {
 
   async ngOnInit() {
     if (Capacitor.getPlatform() !== 'web') {
-      await StatusBar.setOverlaysWebView({ overlay: false });
-      await StatusBar.setBackgroundColor({ color: '#ffffff' });
-      await StatusBar.setStyle({ style: StatusBarStyle.Dark });
       await NavigationBar.setNavigationBarColor({ color: '#ffffff', darkButtons: true });
     }
   }

--- a/mobile/calorie-counter/src/main.ts
+++ b/mobile/calorie-counter/src/main.ts
@@ -7,14 +7,15 @@ import { AppComponent } from "./app/app.component";
 import { routes } from "./app/routes";
 import { AuthInterceptor } from "./app/services/auth.interceptor";
 import { Capacitor } from "@capacitor/core";
-import { StatusBar } from "@capacitor/status-bar";
+import { StatusBar, Style as StatusBarStyle } from "@capacitor/status-bar";
 
 // Configure Android status bar
 (async () => {
   try {
     if (Capacitor.getPlatform() === "android") {
-      await StatusBar.setOverlaysWebView({ overlay: false });
-      await StatusBar.setBackgroundColor({ color: "#000000" });
+      await StatusBar.setOverlaysWebView({ overlay: true });
+      await StatusBar.setBackgroundColor({ color: "#ffffff" });
+      await StatusBar.setStyle({ style: StatusBarStyle.Dark });
     }
   } catch {}
 })();


### PR DESCRIPTION
## Summary
- Ensure Android status bar overlays the WebView and shows dark icons on a white background
- Remove redundant status-bar setup from AppComponent and keep navigation bar color

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Could not resolve "capacitor-plugin-safe-area")*


------
https://chatgpt.com/codex/tasks/task_e_68bf00d3ee8c83318e639ab0f1982914