### PR TITLE
Enable dark theme in Angular Material

### DIFF
--- a/mobile/calorie-counter/angular.json
+++ b/mobile/calorie-counter/angular.json
@@ -46,7 +46,7 @@
               }
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/azure-blue.css",
+              "@angular/material/prebuilt-themes/pink-bluegrey.css",
               "src/styles.scss"
             ],
             "scripts": []
@@ -110,7 +110,7 @@
               }
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/azure-blue.css",
+              "@angular/material/prebuilt-themes/pink-bluegrey.css",
               "src/styles.scss"
             ],
             "scripts": []

--- a/mobile/calorie-counter/src/index.html
+++ b/mobile/calorie-counter/src/index.html
@@ -20,7 +20,7 @@
     }, window.environment || {});
   </script>
 </head>
-<body>
+<body class="mat-app-background">
   <app-root></app-root>
 </body>
 </html>

--- a/mobile/calorie-counter/src/styles.scss
+++ b/mobile/calorie-counter/src/styles.scss
@@ -33,7 +33,7 @@ html, body {
 body {
   margin: 0;
   font-family: "Roboto", sans-serif;
-  background: #f0f2f5;
+  color: var(--mat-app-text-color, #fff);
 }
 
 ion-content::part(scroll) {


### PR DESCRIPTION
## Summary
- Switch Angular Material theme to `pink-bluegrey` dark variant
- Tie global styles to Material tokens and remove light background
- Apply `mat-app-background` class on root page for proper theming

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68bff7f4adc48331ae9d0cfdbc1635a2