### PR TITLE
Add PowerShell script to build Android APK

### DIFF
--- a/mobile/calorie-counter/build-apk.ps1
+++ b/mobile/calorie-counter/build-apk.ps1
@@ -1,0 +1,39 @@
+param(
+    [switch]$Release
+)
+
+$ErrorActionPreference = "Stop"
+
+Push-Location $PSScriptRoot
+try {
+    Write-Host "Installing dependencies..."
+    npm ci | Out-Null
+
+    Write-Host "Building Angular project..."
+    npm run build | Out-Null
+
+    Write-Host "Syncing Capacitor Android platform..."
+    npx cap sync android | Out-Null
+
+    $gradleDir = Join-Path $PSScriptRoot "android"
+    $gradlew = Join-Path $gradleDir "gradlew"
+    if ($IsWindows) { $gradlew += ".bat" }
+
+    Push-Location $gradleDir
+    if ($Release) {
+        Write-Host "Building release APK..."
+        & $gradlew assembleRelease
+    } else {
+        Write-Host "Building debug APK..."
+        & $gradlew assembleDebug
+    }
+    Pop-Location
+
+    Write-Host "APK files:"
+    Get-ChildItem "$gradleDir/app/build/outputs/apk" -Recurse -Filter *.apk | ForEach-Object {
+        Write-Host (" - " + $_.FullName)
+    }
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- add `build-apk.ps1` to automate building the Angular/Capacitor Android APK

## Testing
- ⚠️ `dotnet test FoodBot/FoodBot.sln` *(missing .NET 9 SDK)*
- ⚠️ `npm test` *(Chrome browser not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c01816dbd08331b25a0d9b61d7efa0