### PR TITLE
feat: analyze meals from text description

### DIFF
--- a/FoodBot/Services/OpenAI/IOpenAiClient.cs
+++ b/FoodBot/Services/OpenAI/IOpenAiClient.cs
@@ -8,6 +8,7 @@ namespace FoodBot.Services.OpenAI
     public interface IOpenAiClient
     {
         Task<Step1Snapshot?> DetectFromImageAsync(string dataUrl, string? userNote, string visionModel, CancellationToken ct);
+        Task<Step1Snapshot?> DetectFromTextAsync(string description, string model, CancellationToken ct);
         Task<FinalPayload?> ComputeFinalAsync(IEnumerable<object> messagesHistoryWithUserPrompt, string model, CancellationToken ct);
     }
 


### PR DESCRIPTION
## Summary
- support extracting meal composition from plain text using OpenAI
- allow `IOpenAiClient` to parse descriptions and compute macros
- compute full nutrition results for textual meal entries

## Testing
- `dotnet test FoodBot.Tests/FoodBot.Tests.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c13f1755bc8331b1d30bb4f3bfe7c4