### PR TITLE
Generate placeholder images with meal names

### DIFF
--- a/FoodBot/FoodBot.csproj
+++ b/FoodBot/FoodBot.csproj
@@ -19,6 +19,8 @@
     </PackageReference>
     <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="System.Net.Http.Json" Version="9.0.8" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
   </ItemGroup>
 
   <Target Name="BuildClientApp" BeforeTargets="Build">

--- a/FoodBot/Services/TextMealQueueWorker.cs
+++ b/FoodBot/Services/TextMealQueueWorker.cs
@@ -48,7 +48,7 @@ public sealed class TextMealQueueWorker : BackgroundService
                     var conv = await nutrition.AnalyzeTextAsync(next.Description!, stoppingToken);
                     var (imgBytes, imgMime) = next.GenerateImage
                         ? await images.GenerateAsync(next.Description!, stoppingToken)
-                        : images.GeneratePlaceholder();
+                        : images.GeneratePlaceholder(conv?.Result?.dish ?? next.Description!);
                     var result = conv?.Result;
                     var entry = new MealEntry
                     {


### PR DESCRIPTION
## Summary
- render 512x512 placeholder image containing dish name when generation fails
- show meal name placeholder when image generation is disabled
- include ImageSharp packages for drawing text

## Testing
- `dotnet test FoodBot/FoodBot.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c16595db208331a069798565221bb6