### PR TITLE
fix: ensure readable text color in history dialog

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
@@ -20,14 +20,15 @@
 }
 
 /* Корневой контейнер диалога — больше не растягиваем на всю высоту */
-.container {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;            /* было 1x — опечатка */
-  padding: 12px;
-  /* height: 100%;  ← удалено */
-  /* overflow: auto; ← удалено */
-}
+  .container {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;            /* было 1x — опечатка */
+    padding: 12px;
+    color: rgba(0, 0, 0, 0.87); /* ensure readable text on light background */
+    /* height: 100%;  ← удалено */
+    /* overflow: auto; ← удалено */
+  }
 
 .photo {
   align-self: center;


### PR DESCRIPTION
## Summary
- force dark text color in `HistoryDetailDialogComponent` so dialog content isn't white on white

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c17487d714833197ba241b20a2aa11