### PR TITLE
Prefill clarify note from text descriptions

### DIFF
--- a/FoodBot/Services/TextMealQueueWorker.cs
+++ b/FoodBot/Services/TextMealQueueWorker.cs
@@ -72,7 +72,8 @@ public sealed class TextMealQueueWorker : BackgroundService
                         WeightG = result?.weight_g ?? 0,
                         Model = "app",
                         Step1Json = conv != null ? System.Text.Json.JsonSerializer.Serialize(conv.Step1) : null,
-                        ReasoningPrompt = conv?.ReasoningPrompt
+                        ReasoningPrompt = conv?.ReasoningPrompt,
+                        ClarifyNote = next.Description
                     };
                     db.Meals.Add(entry);
                     db.PendingMeals.Remove(next);


### PR DESCRIPTION
## Summary
- preserve initial text descriptions as `ClarifyNote` when processing text-based meals

## Testing
- `dotnet test FoodBot/FoodBot.sln` *(fails: An error occurred trying to start process 'pdflatex')*


------
https://chatgpt.com/codex/tasks/task_e_68c17b54eb4883318cfd0563079f7fd5