### PR TITLE
Support text clarification queue for meals

### DIFF
--- a/FoodBot/Services/PhotoQueueWorker.cs
+++ b/FoodBot/Services/PhotoQueueWorker.cs
@@ -38,7 +38,13 @@ public sealed class PhotoQueueWorker : BackgroundService
                     .OrderBy(x => x.CreatedAtUtc)
                     .FirstOrDefaultAsync(stoppingToken);
                 var nextClar = await db.PendingClarifies
-                    .OrderBy(x => x.CreatedAtUtc)
+                    .Join(db.Meals,
+                        c => new { c.ChatId, c.MealId },
+                        m => new { m.ChatId, MealId = m.Id },
+                        (c, m) => new { Clar = c, Meal = m })
+                    .Where(x => x.Meal.ImageBytes != null && x.Meal.ImageBytes.Length > 0)
+                    .OrderBy(x => x.Clar.CreatedAtUtc)
+                    .Select(x => x.Clar)
                     .FirstOrDefaultAsync(stoppingToken);
 
                 if (nextPhoto == null && nextClar == null)


### PR DESCRIPTION
## Summary
- handle clarification queue for text-only meals
- process image clarifications only when meal has image

## Testing
- `dotnet test FoodBot/FoodBot.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c2651e570c8331a3f2146d80039d8c