### PR TITLE
Add meal source type and route clarifications

### DIFF
--- a/FoodBot/Data/MealEntry.cs
+++ b/FoodBot/Data/MealEntry.cs
@@ -3,6 +3,12 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace FoodBot.Data;
 
+public enum MealSourceType
+{
+    Photo = 0,
+    Description = 1
+}
+
 public class MealEntry
 {
     [Key] public int Id { get; set; }
@@ -14,6 +20,8 @@ public class MealEntry
 
     // When saved
     public DateTimeOffset CreatedAtUtc { get; set; }
+
+    public MealSourceType SourceType { get; set; }
 
     // Image
     public string FileId { get; set; } = null!;

--- a/FoodBot/Migrations/20250915130000_sourcetype.cs
+++ b/FoodBot/Migrations/20250915130000_sourcetype.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using FoodBot.Data;
+
+#nullable disable
+
+namespace FoodBot.Migrations
+{
+    [DbContext(typeof(BotDbContext))]
+    [Migration("20250915130000_sourcetype")]
+    public partial class sourcetype : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SourceType",
+                table: "Meals",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SourceType",
+                table: "Meals");
+        }
+    }
+}

--- a/FoodBot/Migrations/BotDbContextModelSnapshot.cs
+++ b/FoodBot/Migrations/BotDbContextModelSnapshot.cs
@@ -163,6 +163,9 @@ namespace FoodBot.Migrations
                     b.Property<decimal?>("FatsG")
                         .HasColumnType("decimal(10,2)");
 
+                    b.Property<int>("SourceType")
+                        .HasColumnType("int");
+
                     b.Property<string>("FileId")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");

--- a/FoodBot/Services/PhotoQueueWorker.cs
+++ b/FoodBot/Services/PhotoQueueWorker.cs
@@ -42,7 +42,7 @@ public sealed class PhotoQueueWorker : BackgroundService
                         c => new { c.ChatId, c.MealId },
                         m => new { m.ChatId, MealId = m.Id },
                         (c, m) => new { Clar = c, Meal = m })
-                    .Where(x => x.Meal.ImageBytes != null && x.Meal.ImageBytes.Length > 0)
+                    .Where(x => x.Meal.SourceType == MealSourceType.Photo)
                     .OrderBy(x => x.Clar.CreatedAtUtc)
                     .Select(x => x.Clar)
                     .FirstOrDefaultAsync(stoppingToken);
@@ -136,6 +136,7 @@ public sealed class PhotoQueueWorker : BackgroundService
                             UserId = 0,
                             Username = "app",
                             CreatedAtUtc = DateTimeOffset.UtcNow,
+                            SourceType = MealSourceType.Photo,
                             FileId = string.Empty,
                             FileMime = next.FileMime,
                             ImageBytes = next.ImageBytes,

--- a/FoodBot/Services/TextMealQueueWorker.cs
+++ b/FoodBot/Services/TextMealQueueWorker.cs
@@ -41,7 +41,7 @@ public sealed class TextMealQueueWorker : BackgroundService
                         c => new { c.ChatId, c.MealId },
                         m => new { m.ChatId, MealId = m.Id },
                         (c, m) => new { Clar = c, Meal = m })
-                    .Where(x => x.Meal.ImageBytes == null || x.Meal.ImageBytes.Length == 0)
+                    .Where(x => x.Meal.SourceType == MealSourceType.Description)
                     .OrderBy(x => x.Clar.CreatedAtUtc)
                     .Select(x => x.Clar)
                     .FirstOrDefaultAsync(stoppingToken);
@@ -114,6 +114,7 @@ public sealed class TextMealQueueWorker : BackgroundService
                         UserId = 0,
                         Username = "app",
                         CreatedAtUtc = DateTimeOffset.UtcNow,
+                        SourceType = MealSourceType.Description,
                         FileId = string.Empty,
                         FileMime = imgMime,
                         ImageBytes = imgBytes,


### PR DESCRIPTION
## Summary
- Track the source of each meal (photo or description)
- Route clarification jobs based on meal source
- Support direct text clarifications for text-based meals

## Testing
- `dotnet build`
- `dotnet test` *(fails: pdflatex missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c272b5c7048331b91516c223b347ad