### PR TITLE
Handle invalid webhook JSON

### DIFF
--- a/FoodBot/Extensions/BotExtensions.cs
+++ b/FoodBot/Extensions/BotExtensions.cs
@@ -175,7 +175,17 @@ public static class BotExtensions
         var secret = app.Configuration["Telegram:WebhookSecretPath"] ?? "my-secret";
         app.MapPost($"/bot/{secret}", async (HttpContext http, UpdateHandler handler, ILogger<Program> logger, CancellationToken ct) =>
         {
-            var update = await System.Text.Json.JsonSerializer.DeserializeAsync<Update>(http.Request.Body, cancellationToken: ct);
+            Update? update;
+            try
+            {
+                update = await System.Text.Json.JsonSerializer.DeserializeAsync<Update>(http.Request.Body, cancellationToken: ct);
+            }
+            catch (JsonException ex)
+            {
+                logger.LogWarning(ex, "Invalid update payload");
+                return Results.BadRequest("Invalid update payload");
+            }
+
             if (update != null)
             {
                 _ = Task.Run(async () =>


### PR DESCRIPTION
## Summary
- return 400 Bad Request when webhook payload JSON is invalid

## Testing
- `dotnet test FoodBot/FoodBot.sln` *(fails: An error occurred trying to start process 'pdflatex')*

------
https://chatgpt.com/codex/tasks/task_e_68c2f0ff18888331be6d4cf8bce8cc04