### PR TITLE
Refactor analysis prompt building with period strategies

### DIFF
--- a/FoodBot/Extensions/BotExtensions.cs
+++ b/FoodBot/Extensions/BotExtensions.cs
@@ -60,7 +60,16 @@ public static class BotExtensions
         services.AddScoped<StatsService>();
         services.AddScoped<PersonalCardService>();
         services.AddScoped<ReportDataLoader>();
-        services.AddScoped<AnalysisPromptBuilder>();
+        services.AddScoped<DailyPromptBuilder>();
+        services.AddScoped<WeeklyPromptBuilder>();
+        services.AddScoped<MonthlyPromptBuilder>();
+        services.AddScoped<QuarterlyPromptBuilder>();
+
+        services.AddScoped<IReportStrategy, DailyReportStrategy>();
+        services.AddScoped<IReportStrategy, WeeklyReportStrategy>();
+        services.AddScoped<IReportStrategy, MonthlyReportStrategy>();
+        services.AddScoped<IReportStrategy, QuarterlyReportStrategy>();
+
         services.AddScoped<AnalysisGenerator>();
         services.AddScoped<DietAnalysisService>();
         services.AddScoped<AnalysisPdfService>();

--- a/FoodBot/Services/AnalysisPromptBuilder.cs
+++ b/FoodBot/Services/AnalysisPromptBuilder.cs
@@ -3,10 +3,25 @@ using FoodBot.Models;
 
 namespace FoodBot.Services;
 
-public sealed class AnalysisPromptBuilder
+/// <summary>
+/// Base prompt builder that contains shared instructions for all analysis reports.
+/// Concrete report builders override <see cref="PeriodPrompt"/> to provide
+/// period-specific guidance and optionally <see cref="Model"/> for model name.
+/// </summary>
+public abstract class AnalysisPromptBuilder : IPromptBuilder
 {
-    public string Build(ReportDataLoader.ReportData report, AnalysisPeriod period)
+    /// <summary>LLM model name or <c>null</c> to use default.</summary>
+    public virtual string? Model => "gpt-4o-mini";
+
+    /// <summary>Gets period specific prompt instructions.</summary>
+    protected abstract string PeriodPrompt { get; }
+
+    /// <inheritdoc />
+    public string Build(object data)
     {
+        if (data is not ReportDataLoader.ReportData report)
+            throw new ArgumentException("Invalid report data", nameof(data));
+
         var instructionsRu = $@"Ты — внимательный клинический нутрициолог.
 Анализируй ТОЛЬКО фактически съеденное с начала периода до текущего момента.
 Весь анализ привязывай к локальному времени пользователя (Москва, UTC+3). Учитывай время каждого приёма.
@@ -29,18 +44,9 @@ public sealed class AnalysisPromptBuilder
 Стиль — конкретно и без воды.
 ";
 
-        var periodPrompt = period switch
-        {
-            AnalysisPeriod.Day => "Сформируй почасовой план на остаток текущего дня, используя remainingHourGrid.",
-            AnalysisPeriod.Week => "Сформируй общие рекомендации на текущую неделю. План на конец дня не нужен.",
-            AnalysisPeriod.Month => "Сформируй общие рекомендации на текущий месяц. План на конец дня не нужен.",
-            AnalysisPeriod.Quarter => "Сформируй общие рекомендации на текущий квартал. План на конец дня не нужен.",
-            _ => "Сформируй рекомендации на указанный период."
-        };
-
         var reqObj = new
         {
-            model = "gpt-4o-mini",
+            model = Model ?? "gpt-4o-mini",
             input = new object[]
             {
                 new { role = "system", content = "You are a helpful dietologist." },
@@ -50,7 +56,7 @@ public sealed class AnalysisPromptBuilder
                     content = new object[]
                     {
                         new { type = "input_text", text = instructionsRu },
-                        new { type = "input_text", text = periodPrompt },
+                        new { type = "input_text", text = PeriodPrompt },
                         new { type = "input_text", text = JsonSerializer.Serialize(report.Data) }
                     }
                 }
@@ -60,4 +66,3 @@ public sealed class AnalysisPromptBuilder
         return JsonSerializer.Serialize(reqObj);
     }
 }
-

--- a/FoodBot/Services/DailyPromptBuilder.cs
+++ b/FoodBot/Services/DailyPromptBuilder.cs
@@ -1,0 +1,9 @@
+namespace FoodBot.Services;
+
+/// <summary>
+/// Prompt builder for daily analysis reports.
+/// </summary>
+public sealed class DailyPromptBuilder : AnalysisPromptBuilder
+{
+    protected override string PeriodPrompt => "Сформируй почасовой план на остаток текущего дня, используя remainingHourGrid.";
+}

--- a/FoodBot/Services/DailyReportStrategy.cs
+++ b/FoodBot/Services/DailyReportStrategy.cs
@@ -1,0 +1,10 @@
+using FoodBot.Models;
+
+namespace FoodBot.Services;
+
+public sealed class DailyReportStrategy : IReportStrategy
+{
+    public AnalysisPeriod Period => AnalysisPeriod.Day;
+    public IPromptBuilder PromptBuilder { get; }
+    public DailyReportStrategy(DailyPromptBuilder builder) => PromptBuilder = builder;
+}

--- a/FoodBot/Services/IPromptBuilder.cs
+++ b/FoodBot/Services/IPromptBuilder.cs
@@ -1,0 +1,7 @@
+namespace FoodBot.Services;
+
+public interface IPromptBuilder
+{
+    string Build(object data);
+    string? Model { get; }
+}

--- a/FoodBot/Services/IReportStrategy.cs
+++ b/FoodBot/Services/IReportStrategy.cs
@@ -1,0 +1,9 @@
+using FoodBot.Models;
+
+namespace FoodBot.Services;
+
+public interface IReportStrategy
+{
+    AnalysisPeriod Period { get; }
+    IPromptBuilder PromptBuilder { get; }
+}

--- a/FoodBot/Services/MonthlyPromptBuilder.cs
+++ b/FoodBot/Services/MonthlyPromptBuilder.cs
@@ -1,0 +1,9 @@
+namespace FoodBot.Services;
+
+/// <summary>
+/// Prompt builder for monthly analysis reports.
+/// </summary>
+public sealed class MonthlyPromptBuilder : AnalysisPromptBuilder
+{
+    protected override string PeriodPrompt => "Сформируй общие рекомендации на текущий месяц. План на конец дня не нужен.";
+}

--- a/FoodBot/Services/MonthlyReportStrategy.cs
+++ b/FoodBot/Services/MonthlyReportStrategy.cs
@@ -1,0 +1,10 @@
+using FoodBot.Models;
+
+namespace FoodBot.Services;
+
+public sealed class MonthlyReportStrategy : IReportStrategy
+{
+    public AnalysisPeriod Period => AnalysisPeriod.Month;
+    public IPromptBuilder PromptBuilder { get; }
+    public MonthlyReportStrategy(MonthlyPromptBuilder builder) => PromptBuilder = builder;
+}

--- a/FoodBot/Services/QuarterlyPromptBuilder.cs
+++ b/FoodBot/Services/QuarterlyPromptBuilder.cs
@@ -1,0 +1,9 @@
+namespace FoodBot.Services;
+
+/// <summary>
+/// Prompt builder for quarterly analysis reports.
+/// </summary>
+public sealed class QuarterlyPromptBuilder : AnalysisPromptBuilder
+{
+    protected override string PeriodPrompt => "Сформируй общие рекомендации на текущий квартал. План на конец дня не нужен.";
+}

--- a/FoodBot/Services/QuarterlyReportStrategy.cs
+++ b/FoodBot/Services/QuarterlyReportStrategy.cs
@@ -1,0 +1,10 @@
+using FoodBot.Models;
+
+namespace FoodBot.Services;
+
+public sealed class QuarterlyReportStrategy : IReportStrategy
+{
+    public AnalysisPeriod Period => AnalysisPeriod.Quarter;
+    public IPromptBuilder PromptBuilder { get; }
+    public QuarterlyReportStrategy(QuarterlyPromptBuilder builder) => PromptBuilder = builder;
+}

--- a/FoodBot/Services/WeeklyPromptBuilder.cs
+++ b/FoodBot/Services/WeeklyPromptBuilder.cs
@@ -1,0 +1,9 @@
+namespace FoodBot.Services;
+
+/// <summary>
+/// Prompt builder for weekly analysis reports.
+/// </summary>
+public sealed class WeeklyPromptBuilder : AnalysisPromptBuilder
+{
+    protected override string PeriodPrompt => "Сформируй общие рекомендации на текущую неделю. План на конец дня не нужен.";
+}

--- a/FoodBot/Services/WeeklyReportStrategy.cs
+++ b/FoodBot/Services/WeeklyReportStrategy.cs
@@ -1,0 +1,10 @@
+using FoodBot.Models;
+
+namespace FoodBot.Services;
+
+public sealed class WeeklyReportStrategy : IReportStrategy
+{
+    public AnalysisPeriod Period => AnalysisPeriod.Week;
+    public IPromptBuilder PromptBuilder { get; }
+    public WeeklyReportStrategy(WeeklyPromptBuilder builder) => PromptBuilder = builder;
+}


### PR DESCRIPTION
## Summary
- add IPromptBuilder interface and base AnalysisPromptBuilder
- implement daily/weekly/monthly/quarterly prompt builders and strategies
- wire up DI to use period strategies in DietAnalysisService

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b5117bbc8331938c0f4eb21db4f8