### PR TITLE
Refactor report data loading with period-specific loaders

### DIFF
--- a/FoodBot/Extensions/BotExtensions.cs
+++ b/FoodBot/Extensions/BotExtensions.cs
@@ -63,7 +63,10 @@ public static class BotExtensions
         services.AddScoped<PdfReportService>();
         services.AddScoped<StatsService>();
         services.AddScoped<PersonalCardService>();
-        services.AddScoped<ReportDataLoader>();
+        services.AddScoped<IReportDataLoader<DailyReportData>, DailyDataLoader>();
+        services.AddScoped<IReportDataLoader<WeeklyReportData>, WeeklyDataLoader>();
+        services.AddScoped<IReportDataLoader<MonthlyReportData>, MonthlyDataLoader>();
+        services.AddScoped<IReportDataLoader<QuarterlyReportData>, QuarterlyDataLoader>();
         services.AddScoped<DailyPromptBuilder>();
         services.AddScoped<WeeklyPromptBuilder>();
         services.AddScoped<MonthlyPromptBuilder>();

--- a/FoodBot/Services/AnalysisPromptBuilder.cs
+++ b/FoodBot/Services/AnalysisPromptBuilder.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using FoodBot.Models;
+using FoodBot.Services.Reports;
 
 namespace FoodBot.Services;
 
@@ -19,7 +20,7 @@ public abstract class AnalysisPromptBuilder : IPromptBuilder
     /// <inheritdoc />
     public string Build(object data)
     {
-        if (data is not ReportDataLoader.ReportData report)
+        if (data is not ReportData report)
             throw new ArgumentException("Invalid report data", nameof(data));
 
         var instructionsRu = $@"Ты — внимательный клинический нутрициолог.

--- a/FoodBot/Services/Reports/DailyDataLoader.cs
+++ b/FoodBot/Services/Reports/DailyDataLoader.cs
@@ -1,0 +1,11 @@
+using FoodBot.Data;
+using FoodBot.Models;
+
+namespace FoodBot.Services.Reports;
+
+public sealed class DailyDataLoader : ReportDataLoaderBase<DailyReportData>
+{
+    public DailyDataLoader(BotDbContext db) : base(db) { }
+    protected override AnalysisPeriod Period => AnalysisPeriod.Day;
+}
+

--- a/FoodBot/Services/Reports/DailyReportStrategy.cs
+++ b/FoodBot/Services/Reports/DailyReportStrategy.cs
@@ -3,10 +3,10 @@ using FoodBot.Services;
 
 namespace FoodBot.Services.Reports;
 
-public sealed class DailyReportStrategy : ReportStrategyBase
+public sealed class DailyReportStrategy : ReportStrategyBase<DailyReportData>
 {
     public DailyReportStrategy(
-        ReportDataLoader loader,
+        IReportDataLoader<DailyReportData> loader,
         DailyPromptBuilder promptBuilder,
         AnalysisGenerator generator)
         : base(AnalysisPeriod.Day, loader, promptBuilder, generator)

--- a/FoodBot/Services/Reports/IReportDataLoader.cs
+++ b/FoodBot/Services/Reports/IReportDataLoader.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FoodBot.Services.Reports;
+
+public interface IReportDataLoader<TData>
+{
+    Task<TData> LoadAsync(long chatId, CancellationToken ct);
+}
+

--- a/FoodBot/Services/Reports/MonthlyDataLoader.cs
+++ b/FoodBot/Services/Reports/MonthlyDataLoader.cs
@@ -1,0 +1,11 @@
+using FoodBot.Data;
+using FoodBot.Models;
+
+namespace FoodBot.Services.Reports;
+
+public sealed class MonthlyDataLoader : ReportDataLoaderBase<MonthlyReportData>
+{
+    public MonthlyDataLoader(BotDbContext db) : base(db) { }
+    protected override AnalysisPeriod Period => AnalysisPeriod.Month;
+}
+

--- a/FoodBot/Services/Reports/MonthlyReportStrategy.cs
+++ b/FoodBot/Services/Reports/MonthlyReportStrategy.cs
@@ -3,10 +3,10 @@ using FoodBot.Services;
 
 namespace FoodBot.Services.Reports;
 
-public sealed class MonthlyReportStrategy : ReportStrategyBase
+public sealed class MonthlyReportStrategy : ReportStrategyBase<MonthlyReportData>
 {
     public MonthlyReportStrategy(
-        ReportDataLoader loader,
+        IReportDataLoader<MonthlyReportData> loader,
         MonthlyPromptBuilder promptBuilder,
         AnalysisGenerator generator)
         : base(AnalysisPeriod.Month, loader, promptBuilder, generator)

--- a/FoodBot/Services/Reports/QuarterlyDataLoader.cs
+++ b/FoodBot/Services/Reports/QuarterlyDataLoader.cs
@@ -1,0 +1,11 @@
+using FoodBot.Data;
+using FoodBot.Models;
+
+namespace FoodBot.Services.Reports;
+
+public sealed class QuarterlyDataLoader : ReportDataLoaderBase<QuarterlyReportData>
+{
+    public QuarterlyDataLoader(BotDbContext db) : base(db) { }
+    protected override AnalysisPeriod Period => AnalysisPeriod.Quarter;
+}
+

--- a/FoodBot/Services/Reports/QuarterlyReportStrategy.cs
+++ b/FoodBot/Services/Reports/QuarterlyReportStrategy.cs
@@ -3,10 +3,10 @@ using FoodBot.Services;
 
 namespace FoodBot.Services.Reports;
 
-public sealed class QuarterlyReportStrategy : ReportStrategyBase
+public sealed class QuarterlyReportStrategy : ReportStrategyBase<QuarterlyReportData>
 {
     public QuarterlyReportStrategy(
-        ReportDataLoader loader,
+        IReportDataLoader<QuarterlyReportData> loader,
         QuarterlyPromptBuilder promptBuilder,
         AnalysisGenerator generator)
         : base(AnalysisPeriod.Quarter, loader, promptBuilder, generator)

--- a/FoodBot/Services/Reports/ReportData.cs
+++ b/FoodBot/Services/Reports/ReportData.cs
@@ -1,0 +1,13 @@
+namespace FoodBot.Services.Reports;
+
+public class ReportData
+{
+    public object Data { get; init; } = default!;
+    public string PeriodHuman { get; init; } = string.Empty;
+}
+
+public sealed class DailyReportData : ReportData { }
+public sealed class WeeklyReportData : ReportData { }
+public sealed class MonthlyReportData : ReportData { }
+public sealed class QuarterlyReportData : ReportData { }
+

--- a/FoodBot/Services/Reports/WeeklyDataLoader.cs
+++ b/FoodBot/Services/Reports/WeeklyDataLoader.cs
@@ -1,0 +1,11 @@
+using FoodBot.Data;
+using FoodBot.Models;
+
+namespace FoodBot.Services.Reports;
+
+public sealed class WeeklyDataLoader : ReportDataLoaderBase<WeeklyReportData>
+{
+    public WeeklyDataLoader(BotDbContext db) : base(db) { }
+    protected override AnalysisPeriod Period => AnalysisPeriod.Week;
+}
+

--- a/FoodBot/Services/Reports/WeeklyReportStrategy.cs
+++ b/FoodBot/Services/Reports/WeeklyReportStrategy.cs
@@ -3,10 +3,10 @@ using FoodBot.Services;
 
 namespace FoodBot.Services.Reports;
 
-public sealed class WeeklyReportStrategy : ReportStrategyBase
+public sealed class WeeklyReportStrategy : ReportStrategyBase<WeeklyReportData>
 {
     public WeeklyReportStrategy(
-        ReportDataLoader loader,
+        IReportDataLoader<WeeklyReportData> loader,
         WeeklyPromptBuilder promptBuilder,
         AnalysisGenerator generator)
         : base(AnalysisPeriod.Week, loader, promptBuilder, generator)


### PR DESCRIPTION
## Summary
- introduce `IReportDataLoader` interface and dedicated DTOs
- add `DailyDataLoader`, `WeeklyDataLoader`, `MonthlyDataLoader`, and `QuarterlyDataLoader`
- wire strategies to their loaders and update DI registrations

## Testing
- `~/.dotnet/dotnet test FoodBot.Tests/FoodBot.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c3bec73c40833185bc19d7316f7119