### PR TITLE
feat(reports): add typed report payload classes

### DIFF
--- a/FoodBot.Tests/ReportPayloadSerializationTests.cs
+++ b/FoodBot.Tests/ReportPayloadSerializationTests.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using FoodBot.Services.Reports;
+using Xunit;
+
+public class ReportPayloadSerializationTests
+{
+    [Fact]
+    public void MealEntry_SerializesWithExpectedPropertyNames()
+    {
+        var meal = new MealEntry
+        {
+            Dish = "Soup",
+            LocalDate = "2024-01-01",
+            LocalTime = "12:00",
+            LocalDateTimeIso = "2024-01-01 12:00",
+            Calories = 10,
+            Proteins = 1,
+            Fats = 2,
+            Carbs = 3
+        };
+
+        var json = JsonSerializer.Serialize(meal);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("Soup", root.GetProperty("dish").GetString());
+        Assert.Equal("2024-01-01", root.GetProperty("localDate").GetString());
+        Assert.Equal("12:00", root.GetProperty("localTime").GetString());
+        Assert.Equal("2024-01-01 12:00", root.GetProperty("localDateTimeIso").GetString());
+        Assert.Equal(10m, root.GetProperty("calories").GetDecimal());
+        Assert.Equal(1m, root.GetProperty("proteins").GetDecimal());
+        Assert.Equal(2m, root.GetProperty("fats").GetDecimal());
+        Assert.Equal(3m, root.GetProperty("carbs").GetDecimal());
+    }
+
+    [Fact]
+    public void Totals_SerializesWithExpectedPropertyNames()
+    {
+        var totals = new Totals
+        {
+            Calories = 100,
+            Proteins = 10,
+            Fats = 5,
+            Carbs = 20,
+            MealsCount = 3
+        };
+
+        var json = JsonSerializer.Serialize(totals);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal(100m, root.GetProperty("calories").GetDecimal());
+        Assert.Equal(10m, root.GetProperty("proteins").GetDecimal());
+        Assert.Equal(5m, root.GetProperty("fats").GetDecimal());
+        Assert.Equal(20m, root.GetProperty("carbs").GetDecimal());
+        Assert.Equal(3, root.GetProperty("mealsCount").GetInt32());
+    }
+
+    [Fact]
+    public void Grouping_SerializesWithExpectedPropertyNames()
+    {
+        var grouping = new Grouping
+        {
+            ByHour = new List<GroupByHour> { new GroupByHour { Hour = 9, Count = 1, Kcal = 100 } },
+            ByDay = new List<GroupByDay>
+            {
+                new GroupByDay
+                {
+                    Date = "2024-01-01",
+                    Meals = 2,
+                    Kcal = 200,
+                    Proteins = 20,
+                    Fats = 10,
+                    Carbs = 30
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(grouping);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var hour = root.GetProperty("byHour")[0];
+        Assert.Equal(9, hour.GetProperty("hour").GetInt32());
+        Assert.Equal(1, hour.GetProperty("cnt").GetInt32());
+        Assert.Equal(100m, hour.GetProperty("kcal").GetDecimal());
+
+        var day = root.GetProperty("byDay")[0];
+        Assert.Equal("2024-01-01", day.GetProperty("date").GetString());
+        Assert.Equal(2, day.GetProperty("meals").GetInt32());
+        Assert.Equal(200m, day.GetProperty("kcal").GetDecimal());
+        Assert.Equal(20m, day.GetProperty("prot").GetDecimal());
+        Assert.Equal(10m, day.GetProperty("fat").GetDecimal());
+        Assert.Equal(30m, day.GetProperty("carb").GetDecimal());
+    }
+
+    [Fact]
+    public void ReportPayload_SerializesWithExpectedRootProperties()
+    {
+        var payload = new ReportPayload
+        {
+            Timezone = new TimezoneInfoPayload { Id = "tz", Label = "label", UtcOffset = "+03:00" },
+            Period = new PeriodInfoPayload { Kind = "Day", Label = "Today", StartLocal = "sl", EndLocal = "el", StartUtc = "su", EndUtc = "eu" },
+            Now = new NowInfoPayload { Local = "now", LocalHour = "12", LocalDate = "2024-01-01" },
+            Client = new ClientInfoPayload { Name = "A", Age = 30, Goals = "G", Restrictions = "R" },
+            Meals = new List<MealEntry>(),
+            Totals = new Totals(),
+            Grouping = new Grouping(),
+            DailyPlanContext = new DailyPlanContext { IsDaily = true }
+        };
+
+        var json = JsonSerializer.Serialize(payload);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("timezone", out _));
+        Assert.True(root.TryGetProperty("period", out _));
+        Assert.True(root.TryGetProperty("now", out _));
+        Assert.True(root.TryGetProperty("client", out _));
+        Assert.True(root.TryGetProperty("meals", out _));
+        Assert.True(root.TryGetProperty("totals", out _));
+        Assert.True(root.TryGetProperty("grouping", out _));
+        Assert.True(root.TryGetProperty("dailyPlanContext", out _));
+    }
+}
+

--- a/FoodBot/Services/Reports/ReportData.cs
+++ b/FoodBot/Services/Reports/ReportData.cs
@@ -2,7 +2,10 @@ namespace FoodBot.Services.Reports;
 
 public class ReportData
 {
-    public object Data { get; init; } = default!;
+    /// <summary>Structured payload containing report information.</summary>
+    public ReportPayload Data { get; init; } = new();
+
+    /// <summary>Human readable description of the period covered by the report.</summary>
     public string PeriodHuman { get; init; } = string.Empty;
 }
 

--- a/FoodBot/Services/Reports/ReportPayload.cs
+++ b/FoodBot/Services/Reports/ReportPayload.cs
@@ -1,0 +1,258 @@
+using System.Text.Json.Serialization;
+
+namespace FoodBot.Services.Reports;
+
+/// <summary>
+/// Root payload object returned for report generation.
+/// </summary>
+public sealed class ReportPayload
+{
+    /// <summary>Information about the client's timezone.</summary>
+    [JsonPropertyName("timezone")]
+    public TimezoneInfoPayload Timezone { get; init; } = new();
+
+    /// <summary>Period details for the generated report.</summary>
+    [JsonPropertyName("period")]
+    public PeriodInfoPayload Period { get; init; } = new();
+
+    /// <summary>Current timestamp information.</summary>
+    [JsonPropertyName("now")]
+    public NowInfoPayload Now { get; init; } = new();
+
+    /// <summary>Information about the client.</summary>
+    [JsonPropertyName("client")]
+    public ClientInfoPayload Client { get; init; } = new();
+
+    /// <summary>List of meals consumed during the period.</summary>
+    [JsonPropertyName("meals")]
+    public List<MealEntry> Meals { get; init; } = new();
+
+    /// <summary>Aggregated totals across all meals.</summary>
+    [JsonPropertyName("totals")]
+    public Totals Totals { get; init; } = new();
+
+    /// <summary>Grouping information for meals.</summary>
+    [JsonPropertyName("grouping")]
+    public Grouping Grouping { get; init; } = new();
+
+    /// <summary>Additional context for building a daily plan.</summary>
+    [JsonPropertyName("dailyPlanContext")]
+    public DailyPlanContext DailyPlanContext { get; init; } = new();
+}
+
+/// <summary>Represents a single meal in the report.</summary>
+public sealed class MealEntry
+{
+    /// <summary>Name of the consumed dish.</summary>
+    [JsonPropertyName("dish")]
+    public string Dish { get; init; } = string.Empty;
+
+    /// <summary>Local date of the meal formatted as yyyy-MM-dd.</summary>
+    [JsonPropertyName("localDate")]
+    public string LocalDate { get; init; } = string.Empty;
+
+    /// <summary>Local time of the meal formatted as HH:mm.</summary>
+    [JsonPropertyName("localTime")]
+    public string LocalTime { get; init; } = string.Empty;
+
+    /// <summary>Combined local date and time of the meal.</summary>
+    [JsonPropertyName("localDateTimeIso")]
+    public string LocalDateTimeIso { get; init; } = string.Empty;
+
+    /// <summary>Calories of the meal in Kcal.</summary>
+    [JsonPropertyName("calories")]
+    public decimal Calories { get; init; }
+
+    /// <summary>Proteins amount in grams.</summary>
+    [JsonPropertyName("proteins")]
+    public decimal Proteins { get; init; }
+
+    /// <summary>Fats amount in grams.</summary>
+    [JsonPropertyName("fats")]
+    public decimal Fats { get; init; }
+
+    /// <summary>Carbohydrates amount in grams.</summary>
+    [JsonPropertyName("carbs")]
+    public decimal Carbs { get; init; }
+}
+
+/// <summary>Aggregated totals for the report period.</summary>
+public sealed class Totals
+{
+    /// <summary>Total calories across all meals.</summary>
+    [JsonPropertyName("calories")]
+    public decimal Calories { get; init; }
+
+    /// <summary>Total proteins in grams.</summary>
+    [JsonPropertyName("proteins")]
+    public decimal Proteins { get; init; }
+
+    /// <summary>Total fats in grams.</summary>
+    [JsonPropertyName("fats")]
+    public decimal Fats { get; init; }
+
+    /// <summary>Total carbohydrates in grams.</summary>
+    [JsonPropertyName("carbs")]
+    public decimal Carbs { get; init; }
+
+    /// <summary>Total number of meals recorded.</summary>
+    [JsonPropertyName("mealsCount")]
+    public int MealsCount { get; init; }
+}
+
+/// <summary>Grouping information for analytics.</summary>
+public sealed class Grouping
+{
+    /// <summary>Grouping of meals by hour.</summary>
+    [JsonPropertyName("byHour")]
+    public List<GroupByHour> ByHour { get; init; } = new();
+
+    /// <summary>Grouping of meals by day.</summary>
+    [JsonPropertyName("byDay")]
+    public List<GroupByDay> ByDay { get; init; } = new();
+}
+
+/// <summary>Represents meals grouped by hour.</summary>
+public sealed class GroupByHour
+{
+    /// <summary>Hour of the day in 24-hour format.</summary>
+    [JsonPropertyName("hour")]
+    public int Hour { get; init; }
+
+    /// <summary>Number of meals in the specified hour.</summary>
+    [JsonPropertyName("cnt")]
+    public int Count { get; init; }
+
+    /// <summary>Total calories consumed in the hour.</summary>
+    [JsonPropertyName("kcal")]
+    public decimal Kcal { get; init; }
+}
+
+/// <summary>Represents meals grouped by day.</summary>
+public sealed class GroupByDay
+{
+    /// <summary>Date of the group formatted as yyyy-MM-dd.</summary>
+    [JsonPropertyName("date")]
+    public string Date { get; init; } = string.Empty;
+
+    /// <summary>Number of meals for the day.</summary>
+    [JsonPropertyName("meals")]
+    public int Meals { get; init; }
+
+    /// <summary>Total calories for the day.</summary>
+    [JsonPropertyName("kcal")]
+    public decimal Kcal { get; init; }
+
+    /// <summary>Total proteins for the day.</summary>
+    [JsonPropertyName("prot")]
+    public decimal Proteins { get; init; }
+
+    /// <summary>Total fats for the day.</summary>
+    [JsonPropertyName("fat")]
+    public decimal Fats { get; init; }
+
+    /// <summary>Total carbohydrates for the day.</summary>
+    [JsonPropertyName("carb")]
+    public decimal Carbs { get; init; }
+}
+
+/// <summary>Timezone details.</summary>
+public sealed class TimezoneInfoPayload
+{
+    /// <summary>Timezone identifier.</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>Human readable timezone label.</summary>
+    [JsonPropertyName("label")]
+    public string Label { get; init; } = string.Empty;
+
+    /// <summary>UTC offset formatted as <c>hh:mm</c>.</summary>
+    [JsonPropertyName("utcOffset")]
+    public string UtcOffset { get; init; } = string.Empty;
+}
+
+/// <summary>Represents the report period metadata.</summary>
+public sealed class PeriodInfoPayload
+{
+    /// <summary>Kind of the reporting period (e.g., Day, Week).</summary>
+    [JsonPropertyName("kind")]
+    public string Kind { get; init; } = string.Empty;
+
+    /// <summary>Human readable label for the period.</summary>
+    [JsonPropertyName("label")]
+    public string Label { get; init; } = string.Empty;
+
+    /// <summary>Local start of the period.</summary>
+    [JsonPropertyName("startLocal")]
+    public string StartLocal { get; init; } = string.Empty;
+
+    /// <summary>Local end of the period.</summary>
+    [JsonPropertyName("endLocal")]
+    public string EndLocal { get; init; } = string.Empty;
+
+    /// <summary>UTC start of the period.</summary>
+    [JsonPropertyName("startUtc")]
+    public string StartUtc { get; init; } = string.Empty;
+
+    /// <summary>UTC end of the period.</summary>
+    [JsonPropertyName("endUtc")]
+    public string EndUtc { get; init; } = string.Empty;
+}
+
+/// <summary>Current timestamp details.</summary>
+public sealed class NowInfoPayload
+{
+    /// <summary>Current local timestamp.</summary>
+    [JsonPropertyName("local")]
+    public string Local { get; init; } = string.Empty;
+
+    /// <summary>Current local hour.</summary>
+    [JsonPropertyName("localHour")]
+    public string LocalHour { get; init; } = string.Empty;
+
+    /// <summary>Current local date.</summary>
+    [JsonPropertyName("localDate")]
+    public string LocalDate { get; init; } = string.Empty;
+}
+
+/// <summary>Information about the client receiving the report.</summary>
+public sealed class ClientInfoPayload
+{
+    /// <summary>Client's name.</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    /// <summary>Client's age.</summary>
+    [JsonPropertyName("age")]
+    public int? Age { get; init; }
+
+    /// <summary>Diet goals provided by the client.</summary>
+    [JsonPropertyName("goals")]
+    public string? Goals { get; init; }
+
+    /// <summary>Medical restrictions supplied by the client.</summary>
+    [JsonPropertyName("restrictions")]
+    public string? Restrictions { get; init; }
+}
+
+/// <summary>Context used for generating daily plan recommendations.</summary>
+public sealed class DailyPlanContext
+{
+    /// <summary>Indicates whether the current report is for a single day.</summary>
+    [JsonPropertyName("isDaily")]
+    public bool IsDaily { get; init; }
+
+    /// <summary>Remaining hours in the day formatted as HH:mm.</summary>
+    [JsonPropertyName("remainingHourGrid")]
+    public List<string>? RemainingHourGrid { get; init; }
+
+    /// <summary>Local time of the last meal.</summary>
+    [JsonPropertyName("lastMealLocalTime")]
+    public string? LastMealLocalTime { get; init; }
+
+    /// <summary>Hours elapsed since the last meal.</summary>
+    [JsonPropertyName("hoursSinceLastMeal")]
+    public double? HoursSinceLastMeal { get; init; }
+}
+


### PR DESCRIPTION
## Summary
- add structured report payload types for meals, totals and grouping
- use the new types when loading report data
- cover serialization with unit tests

## Testing
- `/root/.dotnet/dotnet test FoodBot/FoodBot.sln` *(fails: An error occurred trying to start process 'pdflatex' ...)*


------
https://chatgpt.com/codex/tasks/task_e_68c458e91f208331bde4a1485819592e