### PR TITLE
Add markdown copy option for analysis reports

### DIFF
--- a/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.html
+++ b/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.html
@@ -3,6 +3,9 @@
     <mat-icon>arrow_back</mat-icon>
   </button>
   <span class="spacer"></span>
+  <button mat-icon-button (click)="copyMarkdown()" [disabled]="processing || loading || !markdown">
+    <mat-icon>content_copy</mat-icon>
+  </button>
   <button mat-icon-button (click)="downloadPdf()" [disabled]="processing || loading || !markdown">
     <mat-icon>picture_as_pdf</mat-icon>
   </button>

--- a/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.ts
+++ b/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.ts
@@ -5,13 +5,14 @@ import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { Clipboard, ClipboardModule } from '@angular/cdk/clipboard';
 import { AnalysisService } from '../../services/analysis.service';
 import { MarkdownPipe } from '../../pipes/markdown.pipe';
 
 @Component({
   selector: 'app-analysis-report',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule, MatSnackBarModule, MarkdownPipe],
+  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule, MatSnackBarModule, ClipboardModule, MarkdownPipe],
   templateUrl: './analysis-report.page.html',
   styleUrls: ['./analysis-report.page.scss']
 })
@@ -22,7 +23,7 @@ export class AnalysisReportPage implements OnInit {
   loading = false;
   id = 0;
 
-  constructor(private route: ActivatedRoute, private api: AnalysisService, private sb: MatSnackBar) {}
+  constructor(private route: ActivatedRoute, private api: AnalysisService, private sb: MatSnackBar, private clipboard: Clipboard) {}
 
   async ngOnInit() {
     this.id = Number(this.route.snapshot.paramMap.get('id'));
@@ -46,6 +47,16 @@ export class AnalysisReportPage implements OnInit {
       next: () => this.sb.open('Отчёт поставлен в очередь. Готовый PDF придёт в Telegram.', 'OK', { duration: 3000 }),
       error: () => this.sb.open('Не удалось поставить отчёт в очередь.', 'Закрыть', { duration: 4000 })
     });
+  }
+
+  copyMarkdown() {
+    if (!this.markdown) return;
+    const ok = this.clipboard.copy(this.markdown);
+    if (ok) {
+      this.sb.open('Markdown скопирован в буфер обмена.', 'OK', { duration: 2000 });
+    } else {
+      this.sb.open('Не удалось скопировать Markdown.', 'Закрыть', { duration: 4000 });
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add ClipboardModule and copy function in analysis report page
- allow users to copy report markdown via new toolbar button

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c652b7a48083319306917049f539de