### PR TITLE
Implement infinite scrolling on analysis page

### DIFF
--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.html
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.html
@@ -18,48 +18,52 @@
   </button>
 </mat-card>
 
-<mat-card *ngIf="loading">Загрузка…</mat-card>
+<div
+  infiniteScroll
+  [scrollWindow]="false"
+  [infiniteScrollContainer]="'.container'"
+  [fromRoot]="true"
+  [immediateCheck]="true"
+  [infiniteScrollDistance]="1"
+  [infiniteScrollThrottle]="200"
+  (scrolled)="onScrollDown()"
+>
+  <mat-card *ngIf="loading">Загрузка…</mat-card>
 
-<mat-card>
-  <table mat-table [dataSource]="rows" class="history">
+  <mat-card class="history-card">
+    <table mat-table [dataSource]="rows" class="history">
 
-    <ng-container matColumnDef="date">
-      <th mat-header-cell *matHeaderCellDef>Дата</th>
-      <td mat-cell *matCellDef="let r">{{ r.createdAtUtc | date:'yyyy-MM-dd HH:mm' }}</td>
-    </ng-container>
+      <ng-container matColumnDef="date">
+        <th mat-header-cell *matHeaderCellDef>Дата</th>
+        <td mat-cell *matCellDef="let r">{{ r.createdAtUtc | date:'yyyy-MM-dd HH:mm' }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="name">
-      <th mat-header-cell *matHeaderCellDef>Название</th>
-      <td mat-cell *matCellDef="let r" (click)="open(r)" class="link">{{ r.name }}</td>
-    </ng-container>
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef>Название</th>
+        <td mat-cell *matCellDef="let r" (click)="open(r)" class="link">{{ r.name }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="period">
-      <th mat-header-cell *matHeaderCellDef>Тип</th>
-      <td mat-cell *matCellDef="let r">{{ periodLabel(r.period) }}</td>
-    </ng-container>
+      <ng-container matColumnDef="period">
+        <th mat-header-cell *matHeaderCellDef>Тип</th>
+        <td mat-cell *matCellDef="let r">{{ periodLabel(r.period) }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="status">
-      <th mat-header-cell *matHeaderCellDef>Статус</th>
-      <td mat-cell *matCellDef="let r">
-        <mat-chip-set>
-          <mat-chip *ngIf="r.isProcessing" selected>processing</mat-chip>
-          <mat-chip *ngIf="!r.isProcessing && r.hasMarkdown">ok</mat-chip>
-        </mat-chip-set>
-      </td>
-    </ng-container>
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef>Статус</th>
+        <td mat-cell *matCellDef="let r">
+          <mat-chip-set>
+            <mat-chip *ngIf="r.isProcessing" selected>processing</mat-chip>
+            <mat-chip *ngIf="!r.isProcessing && r.hasMarkdown">ok</mat-chip>
+          </mat-chip-set>
+        </td>
+      </ng-container>
 
-    <ng-container matColumnDef="actions">
-      <th mat-header-cell *matHeaderCellDef></th>
-      <td mat-cell *matCellDef="let r">
-        <button mat-icon-button (click)="open(r)" [disabled]="r.isProcessing">
-          <mat-icon>open_in_new</mat-icon>
-        </button>
-      </td>
-    </ng-container>
+      <tr mat-header-row *matHeaderRowDef="cols"></tr>
+      <tr mat-row *matRowDef="let row; columns: cols;"></tr>
+    </table>
 
-    <tr mat-header-row *matHeaderRowDef="cols"></tr>
-    <tr mat-row *matRowDef="let row; columns: cols;"></tr>
-  </table>
+    <div *ngIf="rows.length === 0 && !loading" class="empty">Пока нет сохранённых отчётов.</div>
+  </mat-card>
 
-  <div *ngIf="rows.length === 0 && !loading" class="empty">Пока нет сохранённых отчётов.</div>
-</mat-card>
+  <mat-spinner *ngIf="rows.length < allRows.length"></mat-spinner>
+</div>

--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.scss
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.scss
@@ -8,6 +8,11 @@
 table.history {
   width: 100%;
 }
+
+.history-card {
+  max-width: 640px;
+  margin: 0 auto;
+}
 .link { cursor: pointer; text-decoration: underline; }
 
 .empty {

--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.ts
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.ts
@@ -7,6 +7,8 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { AnalysisService, AnalysisPeriod, ReportRow } from '../../services/analysis.service';
 
 @Component({
@@ -21,14 +23,18 @@ import { AnalysisService, AnalysisPeriod, ReportRow } from '../../services/analy
     MatIconModule,
     MatMenuModule,
     MatChipsModule,
-    MatSnackBarModule
+    MatSnackBarModule,
+    MatProgressSpinnerModule,
+    InfiniteScrollModule
   ],
   templateUrl: './analysis.page.html',
   styleUrls: ['./analysis.page.scss']
 })
 export class AnalysisPage implements OnInit, OnDestroy {
-  cols = ['date', 'name', 'period', 'status', 'actions'];
+  cols = ['date', 'name', 'period', 'status'];
   rows: ReportRow[] = [];
+  allRows: ReportRow[] = [];
+  pageSize = 10;
   loading = false;
   hasProcessing = false;
 
@@ -51,12 +57,21 @@ export class AnalysisPage implements OnInit, OnDestroy {
     try {
       if (showSpinner) this.loading = true;
       const list = await this.api.list();
-      this.rows = list;
+      this.allRows = list;
+      this.rows = [];
+      this.loadMore();
       this.hasProcessing = list.some(x => x.isProcessing);
     } finally {
       this.loading = false;
     }
   }
+
+  loadMore() {
+    const next = this.allRows.slice(this.rows.length, this.rows.length + this.pageSize);
+    if (next.length) this.rows = [...this.rows, ...next];
+  }
+
+  onScrollDown() { this.loadMore(); }
 
   async create(period: AnalysisPeriod) {
     try {


### PR DESCRIPTION
## Summary
- Add infinite scroll to analysis page similar to history
- Remove redundant action column and narrow layout

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c65f0e8d408331ad9a7658d64d5e35