### PR TITLE
Fix back navigation on analysis report page

### DIFF
--- a/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.html
+++ b/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.html
@@ -1,5 +1,5 @@
 <mat-card class="toolbar">
-  <button mat-icon-button routerLink="/analysis">
+  <button mat-icon-button (click)="goBack()">
     <mat-icon>arrow_back</mat-icon>
   </button>
   <span class="spacer"></span>


### PR DESCRIPTION
## Summary
- Handle Android hardware back button by hooking Capacitor's `App.backButton`
- Navigate back via Angular `Location` service when pressing back button

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c66ab1dff88331a0c6e2870550b9cb