### PR TITLE
Add Capacitor app plugin and await listener

### DIFF
--- a/mobile/calorie-counter/package-lock.json
+++ b/mobile/calorie-counter/package-lock.json
@@ -21,6 +21,7 @@
         "@capacitor-community/camera-preview": "^7.0.2",
         "@capacitor-community/speech-recognition": "^7.0.1",
         "@capacitor/android": "^7.4.3",
+        "@capacitor/app": "^7.1.0",
         "@capacitor/camera": "^7.0.2",
         "@capacitor/core": "^7.4.3",
         "@capacitor/filesystem": "^7.1.4",
@@ -1031,6 +1032,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^7.4.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-7.1.0.tgz",
+      "integrity": "sha512-W7m09IWrUjZbo7AKeq+rc/KyucxrJekTBg0l4QCm/yDtCejE3hebxp/W2esU26KKCzMc7H3ClkUw32E9lZkwRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
       }
     },
     "node_modules/@capacitor/camera": {

--- a/mobile/calorie-counter/package.json
+++ b/mobile/calorie-counter/package.json
@@ -23,6 +23,7 @@
     "@capacitor-community/camera-preview": "^7.0.2",
     "@capacitor-community/speech-recognition": "^7.0.1",
     "@capacitor/android": "^7.4.3",
+    "@capacitor/app": "^7.1.0",
     "@capacitor/camera": "^7.0.2",
     "@capacitor/core": "^7.4.3",
     "@capacitor/filesystem": "^7.1.4",

--- a/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.ts
+++ b/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.ts
@@ -37,7 +37,7 @@ export class AnalysisReportPage implements OnInit, OnDestroy {
   async ngOnInit() {
     this.id = Number(this.route.snapshot.paramMap.get('id'));
     this.loading = true;
-    this.backButtonListener = App.addListener('backButton', () => this.goBack());
+    this.backButtonListener = await App.addListener('backButton', () => this.goBack());
     try {
       const res = await this.api.getById(this.id);
       if (res.status === 'processing') {


### PR DESCRIPTION
## Summary
- add `@capacitor/app` dependency to mobile project
- await App back button listener to match new API

## Testing
- `npm run build`
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c66d138b508331a4339f0d95abb5ad