### PR TITLE
fix: handle navigation when analysis report opened directly

### DIFF
--- a/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.ts
+++ b/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule, Location } from '@angular/common';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -31,7 +31,8 @@ export class AnalysisReportPage implements OnInit, OnDestroy {
     private api: AnalysisService,
     private sb: MatSnackBar,
     private clipboard: Clipboard,
-    private location: Location
+    private location: Location,
+    private router: Router
   ) {}
 
   async ngOnInit() {
@@ -70,7 +71,11 @@ export class AnalysisReportPage implements OnInit, OnDestroy {
   }
 
   goBack() {
-    this.location.back();
+    if (history.length > 1) {
+      this.location.back();
+    } else {
+      this.router.navigateByUrl('/analysis');
+    }
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
## Summary
- ensure AnalysisReportPage back button navigates to analysis list when no history

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*


------
https://chatgpt.com/codex/tasks/task_e_68c66faf41d483319b0523fe0248ce1d