### PR TITLE
feat: redesign analysis report toolbar for mobile

### DIFF
--- a/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.html
+++ b/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.html
@@ -1,13 +1,27 @@
 <mat-card class="toolbar">
-  <button mat-icon-button (click)="goBack()">
+  <button mat-button class="toolbar-action" color="primary" (click)="goBack()">
     <mat-icon>arrow_back</mat-icon>
+    <span>Назад</span>
   </button>
-  <span class="spacer"></span>
-  <button mat-icon-button (click)="copyMarkdown()" [disabled]="processing || loading || !markdown">
+  <button
+    mat-button
+    class="toolbar-action"
+    color="accent"
+    (click)="copyMarkdown()"
+    [disabled]="processing || loading || !markdown"
+  >
     <mat-icon>content_copy</mat-icon>
+    <span>Копировать</span>
   </button>
-  <button mat-icon-button (click)="downloadPdf()" [disabled]="processing || loading || !markdown">
+  <button
+    mat-button
+    class="toolbar-action"
+    color="warn"
+    (click)="downloadPdf()"
+    [disabled]="processing || loading || !markdown"
+  >
     <mat-icon>picture_as_pdf</mat-icon>
+    <span>PDF</span>
   </button>
 </mat-card>
 

--- a/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.scss
+++ b/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.scss
@@ -1,7 +1,17 @@
 .toolbar {
   display: flex;
-  align-items: center;
-  gap: 12px;
+  justify-content: space-around;
 }
 
-.spacer { flex: 1 1 auto; }
+.toolbar-action {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.toolbar-action mat-icon {
+  font-size: 36px;
+  height: 36px;
+  width: 36px;
+}


### PR DESCRIPTION
## Summary
- reshape analysis report action panel for mobile with larger colored buttons and labels
- style toolbar horizontally with bigger icons and centered labels

## Testing
- `CHROME_BIN=/tmp/chrome-headless.sh npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Expected '' to contain 'HealthyMeals')*

------
https://chatgpt.com/codex/tasks/task_e_68c672a7e4a48331b4efe2d427b5a195