### PR TITLE
Fix toolbar layout on analysis report page

### DIFF
--- a/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.html
+++ b/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.html
@@ -1,28 +1,30 @@
-<mat-card class="toolbar">
-  <button mat-button class="toolbar-action" color="primary" (click)="goBack()">
-    <mat-icon>arrow_back</mat-icon>
-    <span>Назад</span>
-  </button>
-  <button
-    mat-button
-    class="toolbar-action"
-    color="accent"
-    (click)="copyMarkdown()"
-    [disabled]="processing || loading || !markdown"
-  >
-    <mat-icon>content_copy</mat-icon>
-    <span>Копировать</span>
-  </button>
-  <button
-    mat-button
-    class="toolbar-action"
-    color="warn"
-    (click)="downloadPdf()"
-    [disabled]="processing || loading || !markdown"
-  >
-    <mat-icon>picture_as_pdf</mat-icon>
-    <span>PDF</span>
-  </button>
+<mat-card>
+  <mat-card-content class="toolbar">
+    <button mat-button class="toolbar-action" color="primary" (click)="goBack()">
+      <mat-icon>arrow_back</mat-icon>
+      <span>Назад</span>
+    </button>
+    <button
+      mat-button
+      class="toolbar-action"
+      color="accent"
+      (click)="copyMarkdown()"
+      [disabled]="processing || loading || !markdown"
+    >
+      <mat-icon>content_copy</mat-icon>
+      <span>Копировать</span>
+    </button>
+    <button
+      mat-button
+      class="toolbar-action"
+      color="warn"
+      (click)="downloadPdf()"
+      [disabled]="processing || loading || !markdown"
+    >
+      <mat-icon>picture_as_pdf</mat-icon>
+      <span>PDF</span>
+    </button>
+  </mat-card-content>
 </mat-card>
 
 <mat-card *ngIf="loading">Загрузка…</mat-card>

--- a/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.scss
+++ b/mobile/calorie-counter/src/app/pages/analysis-report/analysis-report.page.scss
@@ -1,6 +1,8 @@
 .toolbar {
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
+  gap: 12px;
+  align-items: center;
 }
 
 .toolbar-action {
@@ -11,7 +13,7 @@
 }
 
 .toolbar-action mat-icon {
-  font-size: 36px;
-  height: 36px;
-  width: 36px;
+  font-size: 32px;
+  height: 32px;
+  width: 32px;
 }


### PR DESCRIPTION
## Summary
- ensure AnalysisReport toolbar icons display in a horizontal row
- adjust styling for compact toolbar and smaller icons

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c6760366708331b417d8e8e7655317