### PR TITLE
Align AnalysisPage toolbar with report style

### DIFF
--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.html
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.html
@@ -1,21 +1,27 @@
-<mat-card class="toolbar">
-  <button mat-raised-button color="primary" [disabled]="hasProcessing || loading" [matMenuTriggerFor]="menu">
-    <mat-icon>add</mat-icon>
-    Создать отчёт
-  </button>
-  <mat-menu #menu="matMenu">
-    <button mat-menu-item (click)="create('day')">День</button>
-    <button mat-menu-item (click)="create('week')">Неделя</button>
-    <button mat-menu-item (click)="create('month')">Месяц</button>
-    <button mat-menu-item (click)="create('quarter')">Квартал</button>
-  </mat-menu>
+<mat-card>
+  <mat-card-content class="toolbar">
+    <button
+      mat-button
+      class="toolbar-action"
+      color="primary"
+      [disabled]="hasProcessing || loading"
+      [matMenuTriggerFor]="menu"
+    >
+      <mat-icon>add</mat-icon>
+      <span>Создать отчёт</span>
+    </button>
+    <mat-menu #menu="matMenu">
+      <button mat-menu-item (click)="create('day')">День</button>
+      <button mat-menu-item (click)="create('week')">Неделя</button>
+      <button mat-menu-item (click)="create('month')">Месяц</button>
+      <button mat-menu-item (click)="create('quarter')">Квартал</button>
+    </mat-menu>
 
-  <span class="spacer"></span>
-
-  <button mat-stroked-button (click)="refresh()">
-    <mat-icon>refresh</mat-icon>
-    Обновить
-  </button>
+    <button mat-button class="toolbar-action" color="accent" (click)="refresh()">
+      <mat-icon>refresh</mat-icon>
+      <span>Обновить</span>
+    </button>
+  </mat-card-content>
 </mat-card>
 
 <div

--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.scss
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.scss
@@ -1,9 +1,22 @@
 ﻿.toolbar {
   display: flex;
-  align-items: center;
+  justify-content: center;
   gap: 12px;
+  align-items: center;
 }
-.spacer { flex: 1 1 auto; }
+
+.toolbar-action {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.toolbar-action mat-icon {
+  font-size: 32px;
+  height: 32px;
+  width: 32px;
+}
 
 table.history {
   width: 100%;


### PR DESCRIPTION
## Summary
- style AnalysisPage toolbar like AnalysisReportPage with vertical icon buttons

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68c67acce2c883319cbbb486a4e34e2a