### PR TITLE
Enable JWT auth for SignalR hubs

### DIFF
--- a/FoodBot/Extensions/BotExtensions.cs
+++ b/FoodBot/Extensions/BotExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
+using System.Threading.Tasks;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Telegram.Bot;
@@ -167,6 +168,22 @@ public static class BotExtensions
                     ValidateAudience = true,
                     ValidateLifetime = true,
                     ClockSkew = TimeSpan.FromMinutes(2)
+                };
+
+                opts.Events = new JwtBearerEvents
+                {
+                    OnMessageReceived = context =>
+                    {
+                        var accessToken = context.Request.Query["access_token"];
+                        var path = context.HttpContext.Request.Path;
+
+                        if (!string.IsNullOrEmpty(accessToken) && path.StartsWithSegments("/hubs"))
+                        {
+                            context.Token = accessToken;
+                        }
+
+                        return Task.CompletedTask;
+                    }
                 };
             });
 


### PR DESCRIPTION
## Summary
- allow JWT tokens from query string to authenticate SignalR hub connections

## Testing
- `dotnet build FoodBot/FoodBot.csproj`
- `dotnet test FoodBot.Tests/FoodBot.Tests.csproj`
- `dotnet run` (manual hub connection check)


------
https://chatgpt.com/codex/tasks/task_e_68c7101be34c83319da4347ee8925af2