### PR TITLE
Fix SignalR history updates when token missing

### DIFF
--- a/mobile/calorie-counter/src/app/services/history-updates.service.ts
+++ b/mobile/calorie-counter/src/app/services/history-updates.service.ts
@@ -12,7 +12,14 @@ export class HistoryUpdatesService {
   constructor(private auth: FoodBotAuthLinkService, private zone: NgZone) {}
 
   private ensureStarted() {
-    if (this.hub) return;
+    const token = this.auth.token;
+    if (!token) return;
+    if (this.hub) {
+      if (this.hub.state === signalR.HubConnectionState.Disconnected) {
+        this.hub.start().catch(err => console.error(err));
+      }
+      return;
+    }
     this.hub = new signalR.HubConnectionBuilder()
       .withUrl(`${this.auth.apiBaseUrl}/hubs/meals`, {
         accessTokenFactory: () => this.auth.token ?? ""


### PR DESCRIPTION
## Summary
- Ensure history update service only starts SignalR connection when an auth token is present
- Restart connection if previously disconnected

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c71af303c483318cd7d42afe7b52f9