### PR TITLE
Restart SignalR hub on token refresh

### DIFF
--- a/mobile/calorie-counter/src/app/services/history-updates.service.ts
+++ b/mobile/calorie-counter/src/app/services/history-updates.service.ts
@@ -9,17 +9,31 @@ export class HistoryUpdatesService {
   private hub?: signalR.HubConnection;
   private updatesSubj = new Subject<MealListItem>();
 
-  constructor(private auth: FoodBotAuthLinkService, private zone: NgZone) {}
+  constructor(private auth: FoodBotAuthLinkService, private zone: NgZone) {
+    this.auth.tokenChanges().subscribe(token => {
+      if (this.hub) {
+        this.hub.stop().finally(() => {
+          if (token) {
+            this.hub!
+              .start()
+              .catch(err => console.error(err));
+          }
+        });
+      } else if (token) {
+        this.ensureStarted();
+      }
+    });
+  }
 
   private ensureStarted() {
     const token = this.auth.token;
-    if (!token) return;
     if (this.hub) {
-      if (this.hub.state === signalR.HubConnectionState.Disconnected) {
+      if (this.hub.state === signalR.HubConnectionState.Disconnected && token) {
         this.hub.start().catch(err => console.error(err));
       }
       return;
     }
+    if (!token) return;
     this.hub = new signalR.HubConnectionBuilder()
       .withUrl(`${this.auth.apiBaseUrl}/hubs/meals`, {
         accessTokenFactory: () => this.auth.token ?? ""


### PR DESCRIPTION
## Summary
- Restart SignalR hub when auth token changes to rejoin chat groups
- Emit token change events from FoodBotAuthLinkService to retry connection after login

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c722e4ebc883319da6f6f00608fdc7