### PR TITLE
Notify clients on photo meal update

### DIFF
--- a/FoodBot/Services/Telegram/UpdateHandler.cs
+++ b/FoodBot/Services/Telegram/UpdateHandler.cs
@@ -198,6 +198,7 @@ $@"Вход через приложение:
                 };
                 db.Meals.Add(entry);
                 await db.SaveChangesAsync(ct);
+                await notifier.MealUpdated(chatId, entry.ToListItem());
 
                 if (conv is not null)
                 {


### PR DESCRIPTION
## Summary
- notify connected clients immediately after saving a photo meal

## Testing
- `~/.dotnet/dotnet test FoodBot.Tests/FoodBot.Tests.csproj` *(fails: An error occurred trying to start process 'pdflatex')*

------
https://chatgpt.com/codex/tasks/task_e_68c799f1e5208331885a79c6eab81e38