### PR TITLE
Add gender, body metrics and activity level to profile

### DIFF
--- a/FoodBot/Data/BotDbContextFactory.cs
+++ b/FoodBot/Data/BotDbContextFactory.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace FoodBot.Data;
+
+public class BotDbContextFactory : IDesignTimeDbContextFactory<BotDbContext>
+{
+    public BotDbContext CreateDbContext(string[] args)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<BotDbContext>();
+        optionsBuilder.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=FoodBot;Trusted_Connection=True;MultipleActiveResultSets=true");
+        return new BotDbContext(optionsBuilder.Options);
+    }
+}

--- a/FoodBot/Data/PersonalCard.cs
+++ b/FoodBot/Data/PersonalCard.cs
@@ -3,6 +3,21 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace FoodBot.Data;
 
+public enum Gender
+{
+    Male,
+    Female
+}
+
+public enum ActivityLevel
+{
+    Minimal,
+    Light,
+    Moderate,
+    High,
+    VeryHigh
+}
+
 public class PersonalCard
 {
     [Key]
@@ -12,6 +27,13 @@ public class PersonalCard
     [MaxLength(256)] public string? Email { get; set; }
     [MaxLength(256)] public string? Name { get; set; }
     public int? BirthYear { get; set; }
+
+    public Gender? Gender { get; set; }
+    public int? HeightCm { get; set; }
+    public decimal? WeightKg { get; set; }
+    public ActivityLevel? ActivityLevel { get; set; }
+    public int? DailyCalories { get; set; }
+
     [MaxLength(1024)] public string? DietGoals { get; set; }
     [MaxLength(1024)] public string? MedicalRestrictions { get; set; }
 }

--- a/FoodBot/Migrations/20250915072358_profile_card.Designer.cs
+++ b/FoodBot/Migrations/20250915072358_profile_card.Designer.cs
@@ -4,6 +4,7 @@ using FoodBot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FoodBot.Migrations
 {
     [DbContext(typeof(BotDbContext))]
-    partial class BotDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250915072358_profile_card")]
+    partial class profile_card
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FoodBot/Migrations/20250915072358_profile_card.cs
+++ b/FoodBot/Migrations/20250915072358_profile_card.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FoodBot.Migrations
+{
+    /// <inheritdoc />
+    public partial class profile_card : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ActivityLevel",
+                table: "PersonalCards",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "DailyCalories",
+                table: "PersonalCards",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Gender",
+                table: "PersonalCards",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "HeightCm",
+                table: "PersonalCards",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "WeightKg",
+                table: "PersonalCards",
+                type: "decimal(18,2)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ActivityLevel",
+                table: "PersonalCards");
+
+            migrationBuilder.DropColumn(
+                name: "DailyCalories",
+                table: "PersonalCards");
+
+            migrationBuilder.DropColumn(
+                name: "Gender",
+                table: "PersonalCards");
+
+            migrationBuilder.DropColumn(
+                name: "HeightCm",
+                table: "PersonalCards");
+
+            migrationBuilder.DropColumn(
+                name: "WeightKg",
+                table: "PersonalCards");
+        }
+    }
+}

--- a/FoodBot/Services/Analysis/PersonalCardService.cs
+++ b/FoodBot/Services/Analysis/PersonalCardService.cs
@@ -17,6 +17,7 @@ public sealed class PersonalCardService
         if (existing == null)
         {
             card.ChatId = chatId;
+            RecalcDailyCalories(card);
             _db.PersonalCards.Add(card);
             await _db.SaveChangesAsync(ct);
             return card;
@@ -25,9 +26,42 @@ public sealed class PersonalCardService
         existing.Email = card.Email;
         existing.Name = card.Name;
         existing.BirthYear = card.BirthYear;
+        existing.Gender = card.Gender;
+        existing.HeightCm = card.HeightCm;
+        existing.WeightKg = card.WeightKg;
+        existing.ActivityLevel = card.ActivityLevel;
         existing.DietGoals = card.DietGoals;
         existing.MedicalRestrictions = card.MedicalRestrictions;
+        RecalcDailyCalories(existing);
         await _db.SaveChangesAsync(ct);
         return existing;
+    }
+
+    private static void RecalcDailyCalories(PersonalCard card)
+    {
+        if (card.Gender.HasValue && card.HeightCm.HasValue && card.WeightKg.HasValue &&
+            card.BirthYear.HasValue && card.ActivityLevel.HasValue)
+        {
+            var age = DateTime.UtcNow.Year - card.BirthYear.Value;
+            var weight = card.WeightKg.Value;
+            var height = card.HeightCm.Value;
+            decimal bmr = card.Gender == Gender.Male
+                ? 10m * weight + 6.25m * height - 5m * age + 5m
+                : 10m * weight + 6.25m * height - 5m * age - 161m;
+            decimal pal = card.ActivityLevel switch
+            {
+                ActivityLevel.Minimal => 1.2m,
+                ActivityLevel.Light => 1.375m,
+                ActivityLevel.Moderate => 1.55m,
+                ActivityLevel.High => 1.725m,
+                ActivityLevel.VeryHigh => 1.9m,
+                _ => 1m
+            };
+            card.DailyCalories = (int)Math.Round(bmr * pal);
+        }
+        else
+        {
+            card.DailyCalories = null;
+        }
     }
 }

--- a/mobile/calorie-counter/src/app/pages/profile/profile.page.html
+++ b/mobile/calorie-counter/src/app/pages/profile/profile.page.html
@@ -19,6 +19,37 @@
     </mat-form-field>
 
     <mat-form-field appearance="fill" class="w-100">
+      <mat-label>Пол</mat-label>
+      <mat-select formControlName="gender">
+        <mat-option [value]="null">—</mat-option>
+        <mat-option *ngFor="let g of genders" [value]="g.value">{{ g.label }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill" class="w-100">
+      <mat-label>Рост (см)</mat-label>
+      <input matInput type="number" formControlName="heightCm" />
+    </mat-form-field>
+
+    <mat-form-field appearance="fill" class="w-100">
+      <mat-label>Вес (кг)</mat-label>
+      <input matInput type="number" formControlName="weightKg" />
+    </mat-form-field>
+
+    <mat-form-field appearance="fill" class="w-100">
+      <mat-label>Коэффициент активности</mat-label>
+      <mat-select formControlName="activityLevel">
+        <mat-option [value]="null">—</mat-option>
+        <mat-option *ngFor="let a of activities" [value]="a.value">{{ a.label }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill" class="w-100">
+      <mat-label>Суточный расход калорий</mat-label>
+      <input matInput formControlName="dailyCalories" readonly />
+    </mat-form-field>
+
+    <mat-form-field appearance="fill" class="w-100">
       <mat-label>Цели диеты</mat-label>
       <textarea matInput formControlName="dietGoals"></textarea>
     </mat-form-field>

--- a/mobile/calorie-counter/src/app/pages/profile/profile.page.ts
+++ b/mobile/calorie-counter/src/app/pages/profile/profile.page.ts
@@ -8,7 +8,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { FoodbotApiService } from '../../services/foodbot-api.service';
-import { PersonalCard } from '../../services/foodbot-api.types';
+import { PersonalCard, Gender, ActivityLevel } from '../../services/foodbot-api.types';
 
 @Component({
   selector: 'app-profile',
@@ -29,12 +29,28 @@ import { PersonalCard } from '../../services/foodbot-api.types';
 export class ProfilePage implements OnInit {
   years: number[] = [];
   form!: FormGroup;
+  genders = [
+    { value: 'male' as Gender, label: 'Мужской' },
+    { value: 'female' as Gender, label: 'Женский' }
+  ];
+  activities = [
+    { value: 'minimal' as ActivityLevel, label: 'Минимальная активность' },
+    { value: 'light' as ActivityLevel, label: 'Лёгкая активность' },
+    { value: 'moderate' as ActivityLevel, label: 'Средняя активность' },
+    { value: 'high' as ActivityLevel, label: 'Высокая активность' },
+    { value: 'veryHigh' as ActivityLevel, label: 'Очень высокая активность' },
+  ];
 
   constructor(private fb: FormBuilder, private api: FoodbotApiService, private snack: MatSnackBar) {
     this.form = this.fb.group({
       email: ['', [Validators.email]],
       name: [''],
       birthYear: [null as number | null],
+      gender: [null as Gender | null],
+      heightCm: [null as number | null],
+      weightKg: [null as number | null],
+      activityLevel: [null as ActivityLevel | null],
+      dailyCalories: [{ value: null as number | null, disabled: true }],
       dietGoals: [''],
       medicalRestrictions: ['']
     });
@@ -44,16 +60,42 @@ export class ProfilePage implements OnInit {
     const currentYear = new Date().getFullYear();
     for (let y = currentYear; y >= 1900; y--) this.years.push(y);
     this.api.getPersonalCard().subscribe(card => {
-      if (card) this.form.patchValue(card);
+      if (card) {
+        this.form.patchValue(card);
+        this.form.get('dailyCalories')!.setValue(card.dailyCalories, { emitEvent: false });
+        this.recalcCalories();
+      }
     });
+    this.form.valueChanges.subscribe(() => this.recalcCalories());
   }
 
   save() {
     if (this.form.invalid) return;
-    const card = this.form.value as PersonalCard;
+    const card = this.form.getRawValue() as PersonalCard;
     this.api.savePersonalCard(card).subscribe({
       next: () => this.snack.open('Сохранено', 'OK', { duration: 1500 }),
       error: () => this.snack.open('Ошибка сохранения', 'OK', { duration: 1500 })
     });
+  }
+
+  private recalcCalories() {
+    const { gender, heightCm, weightKg, birthYear, activityLevel } = this.form.getRawValue();
+    if (gender && heightCm && weightKg && birthYear && activityLevel) {
+      const age = new Date().getFullYear() - birthYear;
+      const bmr = gender === 'male'
+        ? 10 * weightKg + 6.25 * heightCm - 5 * age + 5
+        : 10 * weightKg + 6.25 * heightCm - 5 * age - 161;
+      const palMap: Record<ActivityLevel, number> = {
+        minimal: 1.2,
+        light: 1.375,
+        moderate: 1.55,
+        high: 1.725,
+        veryHigh: 1.9,
+      };
+      const daily = Math.round(bmr * palMap[activityLevel]);
+      this.form.get('dailyCalories')!.setValue(daily, { emitEvent: false });
+    } else {
+      this.form.get('dailyCalories')!.setValue(null, { emitEvent: false });
+    }
   }
 }

--- a/mobile/calorie-counter/src/app/services/foodbot-api.types.ts
+++ b/mobile/calorie-counter/src/app/services/foodbot-api.types.ts
@@ -85,10 +85,24 @@ export interface ExchangeResponse {
   chatId: number;
 }
 
+export type Gender = 'male' | 'female';
+
+export type ActivityLevel =
+  | 'minimal'
+  | 'light'
+  | 'moderate'
+  | 'high'
+  | 'veryHigh';
+
 export interface PersonalCard {
   email: string | null;
   name: string | null;
   birthYear: number | null;
+  gender: Gender | null;
+  heightCm: number | null;
+  weightKg: number | null;
+  activityLevel: ActivityLevel | null;
+  dailyCalories: number | null;
   dietGoals: string | null;
   medicalRestrictions: string | null;
 }


### PR DESCRIPTION
## Summary
- extend `PersonalCard` with gender, height, weight, activity level and daily calories
- recalculate daily calories on save using Mifflin–St Jeor and activity multiplier
- expose new profile fields and auto calorie calculation in mobile client

## Testing
- `dotnet test FoodBot/FoodBot.sln` *(fails: npm run build -- --configuration production exited with code 1)*
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c7be02f8a08331a2d3f8fb669de3fe