### PR TITLE
fix: type activity level

### DIFF
--- a/mobile/calorie-counter/src/app/pages/profile/profile.page.ts
+++ b/mobile/calorie-counter/src/app/pages/profile/profile.page.ts
@@ -79,7 +79,8 @@ export class ProfilePage implements OnInit {
   }
 
   private recalcCalories() {
-    const { gender, heightCm, weightKg, birthYear, activityLevel } = this.form.getRawValue();
+    const { gender, heightCm, weightKg, birthYear, activityLevel } =
+      this.form.getRawValue() as PersonalCard;
     if (gender && heightCm && weightKg && birthYear && activityLevel) {
       const age = new Date().getFullYear() - birthYear;
       const bmr = gender === 'male'


### PR DESCRIPTION
## Summary
- type PersonalCard in `recalcCalories` to avoid implicit `any`

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cb3cf1388331b874c97b767588fe