### PR TITLE
Avoid escaping Cyrillic in analysis prompts

### DIFF
--- a/FoodBot/Services/Analysis/PromptBuilders/BaseAnalysisPromptBuilder.cs
+++ b/FoodBot/Services/Analysis/PromptBuilders/BaseAnalysisPromptBuilder.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Encodings.Web;
 using FoodBot.Services.Reports;
 
 namespace FoodBot.Services;
@@ -21,13 +22,18 @@ public abstract class BaseAnalysisPromptBuilder<TData> : IPromptBuilder<TData>
     /// </remarks>
     protected virtual IEnumerable<object>? ExtraInputs(ReportData<TData> report) => null;
 
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
     /// <inheritdoc />
     public string Build(ReportData<TData> report)
     {
         var content = new List<object>
         {
             new { type = "input_text", text = BuildInstructions(report) },
-            new { type = "input_text", text = JsonSerializer.Serialize(report.Data) }
+            new { type = "input_text", text = JsonSerializer.Serialize(report.Data, JsonOpts) }
         };
 
         var extras = ExtraInputs(report);
@@ -46,7 +52,7 @@ public abstract class BaseAnalysisPromptBuilder<TData> : IPromptBuilder<TData>
             }
         };
 
-        return JsonSerializer.Serialize(reqObj);
+        return JsonSerializer.Serialize(reqObj, JsonOpts);
     }
 }
 


### PR DESCRIPTION
## Summary
- keep Russian characters and quotes in analysis request JSON by disabling encoder escaping

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c80076a7a4833187099586b4f09209