### PR TITLE
Add active state styling to side menu links

### DIFF
--- a/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.html
+++ b/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.html
@@ -1,21 +1,21 @@
 <mat-nav-list>
-  <a mat-list-item routerLink="/history" (click)="close.emit()">
+  <a mat-list-item routerLink="/history" routerLinkActive="active" (click)="close.emit()">
     <mat-icon fontSet="material-icons-outlined" matListItemIcon>history</mat-icon>
     <span matListItemTitle>История</span>
   </a>
-  <a mat-list-item routerLink="/add" (click)="close.emit()">
+  <a mat-list-item routerLink="/add" routerLinkActive="active" (click)="close.emit()">
     <mat-icon fontSet="material-icons-outlined" matListItemIcon>add_a_photo</mat-icon>
     <span matListItemTitle>Добавить</span>
   </a>
-  <a mat-list-item routerLink="/analysis" (click)="close.emit()">
+  <a mat-list-item routerLink="/analysis" routerLinkActive="active" (click)="close.emit()">
     <mat-icon fontSet="material-icons-outlined" matListItemIcon>analytics</mat-icon>
     <span matListItemTitle>Анализ</span>
   </a>
-  <a mat-list-item routerLink="/stats" (click)="close.emit()">
+  <a mat-list-item routerLink="/stats" routerLinkActive="active" (click)="close.emit()">
     <mat-icon fontSet="material-icons-outlined" matListItemIcon>bar_chart</mat-icon>
     <span matListItemTitle>Статистика</span>
   </a>
-  <a mat-list-item routerLink="/profile" (click)="close.emit()">
+  <a mat-list-item routerLink="/profile" routerLinkActive="active" (click)="close.emit()">
     <mat-icon fontSet="material-icons-outlined" matListItemIcon>person</mat-icon>
     <span matListItemTitle>Профиль</span>
   </a>

--- a/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.scss
+++ b/mobile/calorie-counter/src/app/components/side-menu/side-menu.component.scss
@@ -20,3 +20,17 @@ span[matListItemTitle] {
 a.mat-list-item:hover {
   opacity: 0.8;
 }
+
+a.mat-list-item.active {
+  background-color: rgba(72, 119, 166, 0.12);
+  border-radius: 8px;
+}
+
+a.mat-list-item.active span[matListItemTitle] {
+  color: #4877A6;
+  font-weight: 600;
+}
+
+a.mat-list-item.active mat-icon[matListItemIcon] {
+  color: #4877A6;
+}


### PR DESCRIPTION
## Summary
- add `routerLinkActive="active"` to each side-menu navigation link
- style the active navigation link to highlight the current route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c85c9f1b908331ac3539e38cda6589