### PR TITLE
feat: add confirm dialog to history clarify

### DIFF
--- a/mobile/calorie-counter/src/app/components/confirm-dialog/confirm-dialog.component.ts
+++ b/mobile/calorie-counter/src/app/components/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,48 @@
+import { CommonModule } from '@angular/common';
+import { Component, Inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+export interface ConfirmDialogData {
+  title?: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+@Component({
+  selector: 'app-confirm-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  template: `
+    <h2 mat-dialog-title *ngIf="data.title">{{ data.title }}</h2>
+    <mat-dialog-content>
+      <p class="message">{{ data.message }}</p>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button (click)="onCancel()">{{ data.cancelLabel || 'Отмена' }}</button>
+      <button mat-flat-button color="warn" (click)="onConfirm()">{{ data.confirmLabel || 'OK' }}</button>
+    </mat-dialog-actions>
+  `,
+  styles: [
+    `
+      .message {
+        margin: 0;
+      }
+    `
+  ]
+})
+export class ConfirmDialogComponent {
+  constructor(
+    private dialogRef: MatDialogRef<ConfirmDialogComponent, boolean>,
+    @Inject(MAT_DIALOG_DATA) public data: ConfirmDialogData
+  ) {}
+
+  onCancel(): void {
+    this.dialogRef.close(false);
+  }
+
+  onConfirm(): void {
+    this.dialogRef.close(true);
+  }
+}

--- a/mobile/calorie-counter/src/app/pages/history/history-clarify.dialog.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history-clarify.dialog.ts
@@ -2,7 +2,7 @@ import { Component, Inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
-import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogModule, MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
@@ -13,6 +13,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { TextFieldModule } from '@angular/cdk/text-field';
 import { FoodbotApiService } from '../../services/foodbot-api.service';
 import { ClarifyResult } from '../../services/foodbot-api.types';
+import { ConfirmDialogComponent, ConfirmDialogData } from '../../components/confirm-dialog/confirm-dialog.component';
 import { firstValueFrom } from 'rxjs';
 
 @Component({
@@ -159,6 +160,7 @@ export class HistoryClarifyDialogComponent {
     @Inject(MAT_DIALOG_DATA) public data: { mealId: number; createdAtUtc: string; note?: string },
     private api: FoodbotApiService,
     private snack: MatSnackBar,
+    private dialog: MatDialog,
     public dialogRef: MatDialogRef<HistoryClarifyDialogComponent>
   ) {
     this.createdAt = new Date(data.createdAtUtc);
@@ -237,10 +239,21 @@ export class HistoryClarifyDialogComponent {
   }
 
   remove() {
-    if (!confirm('Удалить запись?')) return;
-    this.api.deleteMeal(this.data.mealId).subscribe({
-      next: () => this.dialogRef.close({ deleted: true }),
-      error: () => this.snack.open('Не удалось удалить', 'OK', { duration: 1500 })
+    const dialogRef = this.dialog.open<ConfirmDialogComponent, ConfirmDialogData, boolean>(ConfirmDialogComponent, {
+      data: {
+        title: 'Удаление записи',
+        message: 'Удалить запись?',
+        confirmLabel: 'Удалить',
+        cancelLabel: 'Отмена'
+      }
+    });
+
+    dialogRef.afterClosed().subscribe(confirmed => {
+      if (!confirmed) return;
+      this.api.deleteMeal(this.data.mealId).subscribe({
+        next: () => this.dialogRef.close({ deleted: true }),
+        error: () => this.snack.open('Не удалось удалить', 'OK', { duration: 1500 })
+      });
     });
   }
 }


### PR DESCRIPTION
## Summary
- add a reusable standalone ConfirmDialog component for confirmation prompts
- replace the browser confirm in the history clarify dialog with the new dialog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c85cb6d6288331a9d1949917e371a6