### PR TITLE
Align bottom menu styling with side menu

### DIFF
--- a/mobile/calorie-counter/src/app/app.component.html
+++ b/mobile/calorie-counter/src/app/app.component.html
@@ -27,17 +27,17 @@
     </div>
 
     <!-- Нижний тулбар (поднимаем на safeBottom) -->
-    <mat-toolbar color="primary" class="bottombar" [style.bottom.px]="safeBottom()">
+    <mat-toolbar class="bottombar" [style.bottom.px]="safeBottom()">
       <a mat-button routerLink="/history" routerLinkActive="active">
-        <mat-icon>history</mat-icon>
+        <mat-icon fontSet="material-icons-outlined">history</mat-icon>
         <span>История</span>
       </a>
       <a mat-button routerLink="/add" routerLinkActive="active">
-        <mat-icon>add_a_photo</mat-icon>
+        <mat-icon fontSet="material-icons-outlined">add_a_photo</mat-icon>
         <span>Добавить</span>
       </a>
       <a mat-button routerLink="/analysis" routerLinkActive="active">
-        <mat-icon>analytics</mat-icon>
+        <mat-icon fontSet="material-icons-outlined">analytics</mat-icon>
         <span>Анализ</span>
       </a>
     </mat-toolbar>

--- a/mobile/calorie-counter/src/app/app.component.scss
+++ b/mobile/calorie-counter/src/app/app.component.scss
@@ -62,16 +62,56 @@
   align-items: center;
   height: 56px;                 /* синхронизировано с TS */
   z-index: 1001;
+  background: #ffffff;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.04);
+  padding: 0 8px;
 }
 
-.bottombar a {
+.bottombar a.mat-mdc-button-base {
+  flex: 1;
+  min-width: 0;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  color: inherit;
+  justify-content: center;
+  color: #2B2B2B;
   text-decoration: none;
+  text-transform: none;
+  border-radius: 8px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+
+  .mat-mdc-button__label {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+  }
+
+  mat-icon {
+    color: #4877A6;
+    font-size: 22px;
+    line-height: 1;
+  }
+
+  span {
+    color: inherit;
+    font-size: 16px;
+  }
 }
 
-.bottombar a.active {
-  background: rgba(255, 255, 255, 0.1);
+.bottombar a.mat-mdc-button-base:hover {
+  background: rgba(72, 119, 166, 0.08);
+}
+
+.bottombar a.mat-mdc-button-base.active {
+  background: rgba(72, 119, 166, 0.12);
+  color: #4877A6;
+
+  span {
+    color: #4877A6;
+    font-weight: 600;
+  }
+
+  mat-icon {
+    color: #4877A6;
+  }
 }


### PR DESCRIPTION
## Summary
- switch the bottom toolbar to use the outlined material icon set shared with the side navigation
- restyle the bottom navigation typography, colors, and active states to mirror the side menu design

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68c85e5cf0ec8331a9503799f0dbfcf6