### PR TITLE
Adjust bottom navigation icon and text styling

### DIFF
--- a/mobile/calorie-counter/src/app/app.component.scss
+++ b/mobile/calorie-counter/src/app/app.component.scss
@@ -83,18 +83,23 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 6px;
+    gap: 4px;
+    font-weight: 400;
   }
 
   mat-icon {
     color: #4877A6;
-    font-size: 22px;
+    font-size: 28px;
     line-height: 1;
+    width: 28px;
+    height: 28px;
+    display: block;
   }
 
   span {
     color: inherit;
-    font-size: 16px;
+    font-size: 12px;
+    font-weight: 400;
   }
 }
 
@@ -104,14 +109,4 @@
 
 .bottombar a.mat-mdc-button-base.active {
   background: rgba(72, 119, 166, 0.12);
-  color: #4877A6;
-
-  span {
-    color: #4877A6;
-    font-weight: 600;
-  }
-
-  mat-icon {
-    color: #4877A6;
-  }
 }


### PR DESCRIPTION
## Summary
- enlarge bottom navigation icons to match common bottom bar sizing
- shrink and lighten bottom navigation labels for a compact caption style
- keep icon and label colors consistent when tabs are active while retaining the highlight background

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c86045810483318eb4078726414ea8