### PR TITLE
Adjust bottom bar tab layout

### DIFF
--- a/mobile/calorie-counter/src/app/app.component.html
+++ b/mobile/calorie-counter/src/app/app.component.html
@@ -29,16 +29,22 @@
     <!-- Нижний тулбар (поднимаем на safeBottom) -->
     <mat-toolbar class="bottombar" [style.bottom.px]="safeBottom()">
       <a mat-button routerLink="/history" routerLinkActive="active">
-        <mat-icon fontSet="material-icons-outlined">history</mat-icon>
-        <span>История</span>
+        <span class="bottom-tab">
+          <mat-icon fontSet="material-icons-outlined">history</mat-icon>
+          <span class="bottom-tab__label">История</span>
+        </span>
       </a>
       <a mat-button routerLink="/add" routerLinkActive="active">
-        <mat-icon fontSet="material-icons-outlined">add_a_photo</mat-icon>
-        <span>Добавить</span>
+        <span class="bottom-tab">
+          <mat-icon fontSet="material-icons-outlined">add_a_photo</mat-icon>
+          <span class="bottom-tab__label">Добавить</span>
+        </span>
       </a>
       <a mat-button routerLink="/analysis" routerLinkActive="active">
-        <mat-icon fontSet="material-icons-outlined">analytics</mat-icon>
-        <span>Анализ</span>
+        <span class="bottom-tab">
+          <mat-icon fontSet="material-icons-outlined">analytics</mat-icon>
+          <span class="bottom-tab__label">Анализ</span>
+        </span>
       </a>
     </mat-toolbar>
     @if(safeBottom() > 0)

--- a/mobile/calorie-counter/src/app/app.component.scss
+++ b/mobile/calorie-counter/src/app/app.component.scss
@@ -79,15 +79,14 @@
   border-radius: 8px;
   transition: background-color 0.2s ease, color 0.2s ease;
 
-  .mat-mdc-button__label {
+  .bottom-tab {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 4px;
-    font-weight: 400;
   }
 
-  mat-icon {
+  .bottom-tab mat-icon {
     color: #4877A6;
     font-size: 28px;
     line-height: 1;
@@ -96,7 +95,7 @@
     display: block;
   }
 
-  span {
+  .bottom-tab__label {
     color: inherit;
     font-size: 12px;
     font-weight: 400;


### PR DESCRIPTION
## Summary
- wrap each bottom toolbar tab in a flex column container so labels sit below their icons
- style the new wrapper to center icons and captions and preserve sizing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c86286e15c8331a030b3e93bcb3008