### PR TITLE
Refresh Telegram code before automatic bot launch

### DIFF
--- a/mobile/calorie-counter/src/app/pages/auth/auth.page.html
+++ b/mobile/calorie-counter/src/app/pages/auth/auth.page.html
@@ -4,7 +4,7 @@
       <h2>Вход через Telegram</h2>
       <p>Нажмите кнопку, чтобы открыть бота и подтвердить вход.</p>
       <div class="actions">
-        <button mat-raised-button color="primary" (click)="openBot()" [disabled]="!code">
+        <button mat-raised-button color="primary" (click)="openBotWithFreshCode()" [disabled]="busy || !code">
           <mat-icon>send</mat-icon> Открыть бота
         </button>
       </div>

--- a/mobile/calorie-counter/src/app/pages/auth/auth.page.ts
+++ b/mobile/calorie-counter/src/app/pages/auth/auth.page.ts
@@ -74,6 +74,20 @@ export class AuthPage implements OnInit, OnDestroy {
     this.startAutoRefresh();
   }
 
+  async openBotWithFreshCode() {
+    if (this.busy) return;
+    this.busy = true;
+    try {
+      await this.startFlow();
+      this.openBot();
+    } catch (e) {
+      this.errorMsg = "Не удалось получить код. Проверьте доступность API/CORS.";
+      showErrorAlert(e, "Не удалось получить свежий код");
+    } finally {
+      this.busy = false;
+    }
+  }
+
   async refresh() {
     if (!this.flow) return;
     this.busy = true;


### PR DESCRIPTION
## Summary
- request a fresh login flow before launching the Telegram bot from the automatic tab
- disable the automatic login button while requesting a new code to avoid duplicate clicks

## Testing
- `npm run test -- --watch=false --browsers=ChromeHeadless` *(fails: Chrome binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca4b3de20c8331af8a1225f427191f