### PR TITLE
feat: add dialog for meal notes and improve camera preview

### DIFF
--- a/mobile/calorie-counter/src/app/pages/add-meal/add-meal-note-dialog.component.html
+++ b/mobile/calorie-counter/src/app/pages/add-meal/add-meal-note-dialog.component.html
@@ -1,0 +1,33 @@
+<h2 mat-dialog-title>Описание приёма пищи</h2>
+
+<form class="note-form" [formGroup]="form" (ngSubmit)="sendText()">
+  <div mat-dialog-content class="dialog-content">
+    <mat-form-field appearance="outline">
+      <mat-label>Описание</mat-label>
+      <textarea matInput formControlName="note" rows="4"></textarea>
+      <button *ngIf="noteControl?.value" mat-icon-button matSuffix aria-label="Очистить" (click)="clearNote()">
+        <mat-icon>close</mat-icon>
+      </button>
+    </mat-form-field>
+
+    <div class="mic">
+      <button mat-fab color="primary"
+              matTooltip="Удерживайте для записи"
+              aria-label="Записать голос"
+              (mousedown)="startRecord($event)" (touchstart)="startRecord($event)"
+              (mouseup)="stopRecord()" (mouseleave)="stopRecord()" (touchend)="stopRecord()" (touchcancel)="stopRecord()"
+              [class.recording]="!!recorder" [disabled]="transcribing">
+        <mat-icon>{{ recorder ? 'mic' : 'mic_none' }}</mat-icon>
+      </button>
+      <div class="hint" *ngIf="!recorder">Удерживайте для записи</div>
+      <div class="hint recording" *ngIf="recorder">Запись… отпустите, чтобы остановить</div>
+    </div>
+
+    <mat-progress-bar *ngIf="transcribing" mode="indeterminate"></mat-progress-bar>
+  </div>
+
+  <div mat-dialog-actions align="end">
+    <button mat-stroked-button type="button" (click)="close()">Отмена</button>
+    <button mat-flat-button color="primary" type="submit" [disabled]="!canSend">Отправить</button>
+  </div>
+</form>

--- a/mobile/calorie-counter/src/app/pages/add-meal/add-meal-note-dialog.component.scss
+++ b/mobile/calorie-counter/src/app/pages/add-meal/add-meal-note-dialog.component.scss
@@ -1,0 +1,48 @@
+.note-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.mic {
+  display: grid;
+  justify-items: center;
+  gap: 6px;
+}
+
+.mic .hint {
+  font-size: 12px;
+  opacity: 0.7;
+  text-align: center;
+  line-height: 1.2;
+}
+
+.mic .hint.recording {
+  opacity: 0.9;
+}
+
+.mic button.recording {
+  animation: pulse 1s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(244, 67, 54, 0.45);
+  }
+  70% {
+    box-shadow: 0 0 0 12px rgba(244, 67, 54, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(244, 67, 54, 0);
+  }
+}
+
+[mat-dialog-actions] {
+  padding-top: 0;
+}

--- a/mobile/calorie-counter/src/app/pages/add-meal/add-meal-note-dialog.component.ts
+++ b/mobile/calorie-counter/src/app/pages/add-meal/add-meal-note-dialog.component.ts
@@ -1,0 +1,134 @@
+import { Component, OnDestroy } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { FormBuilder, FormGroup, ReactiveFormsModule } from "@angular/forms";
+import { MatButtonModule } from "@angular/material/button";
+import { MatDialogModule, MatDialogRef } from "@angular/material/dialog";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatIconModule } from "@angular/material/icon";
+import { MatInputModule } from "@angular/material/input";
+import { MatProgressBarModule } from "@angular/material/progress-bar";
+import { MatSnackBar, MatSnackBarModule } from "@angular/material/snack-bar";
+import { MatTooltipModule } from "@angular/material/tooltip";
+import { firstValueFrom } from "rxjs";
+
+import { FoodbotApiService } from "../../services/foodbot-api.service";
+
+@Component({
+  selector: "app-add-meal-note-dialog",
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatButtonModule, MatDialogModule, MatFormFieldModule,
+    MatIconModule, MatInputModule, MatProgressBarModule, MatSnackBarModule, MatTooltipModule
+  ],
+  templateUrl: "./add-meal-note-dialog.component.html",
+  styleUrls: ["./add-meal-note-dialog.component.scss"]
+})
+export class AddMealNoteDialogComponent implements OnDestroy {
+  form: FormGroup;
+  transcribing = false;
+  recorder?: MediaRecorder;
+  private chunks: Blob[] = [];
+
+  constructor(
+    private fb: FormBuilder,
+    private api: FoodbotApiService,
+    private snack: MatSnackBar,
+    private dialogRef: MatDialogRef<AddMealNoteDialogComponent>
+  ) {
+    this.form = this.fb.group({
+      note: [""]
+    });
+  }
+
+  get noteControl() {
+    return this.form.get("note");
+  }
+
+  get canSend(): boolean {
+    const value = this.noteControl?.value as string | null;
+    return !!value && value.trim().length > 0 && !this.transcribing;
+  }
+
+  close() {
+    this.dialogRef.close();
+  }
+
+  clearNote() {
+    this.noteControl?.setValue("");
+  }
+
+  async startRecord(ev: Event) {
+    ev.preventDefault();
+    if (this.transcribing || this.recorder) return;
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      this.chunks = [];
+      const recorder = new MediaRecorder(stream);
+      recorder.addEventListener("dataavailable", e => {
+        if (e.data.size > 0) this.chunks.push(e.data);
+      });
+      recorder.addEventListener("stop", () => {
+        stream.getTracks().forEach(t => t.stop());
+      }, { once: true });
+      recorder.start();
+      this.recorder = recorder;
+    } catch {
+      this.recorder = undefined;
+      this.snack.open("Не удалось получить доступ к микрофону", "OK", { duration: 1500 });
+    }
+  }
+
+  async stopRecord() {
+    if (!this.recorder) return;
+    const recorder = this.recorder;
+    this.recorder = undefined;
+    const stopped = new Promise<void>(resolve =>
+      recorder.addEventListener("stop", () => resolve(), { once: true })
+    );
+    recorder.stop();
+    await stopped;
+    const chunks = this.chunks.slice();
+    if (!chunks.length) return;
+
+    this.transcribing = true;
+    try {
+      const blob = new Blob(chunks, { type: "audio/webm" });
+      const file = new File([blob], "voice.webm", { type: blob.type });
+      const r = await firstValueFrom(this.api.transcribeVoice(file));
+      if (r.text) this.noteControl?.setValue(r.text);
+    } catch {
+      this.snack.open("Не удалось распознать речь", "OK", { duration: 1500 });
+    } finally {
+      this.transcribing = false;
+    }
+  }
+
+  sendText() {
+    if (!this.canSend) return;
+    const note = (this.noteControl?.value as string).trim();
+    this.api.addMealText(note).subscribe({
+      next: () => {
+        this.snack.open("Описание отправлено. Обработка начнётся скоро.", "OK", { duration: 1500 });
+        this.form.reset({ note: "" });
+        this.dialogRef.close(true);
+      },
+      error: () => {
+        this.snack.open("Не удалось отправить описание", "OK", { duration: 2000 });
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    if (this.recorder && this.recorder.state !== "inactive") {
+      try {
+        this.recorder.stop();
+      } catch {
+        // ignore
+      }
+    }
+    this.recorder = undefined;
+    this.chunks = [];
+  }
+}

--- a/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.html
+++ b/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.html
@@ -1,49 +1,47 @@
-﻿<mat-card>
-  <div id="cameraPreview" class="preview-box" *ngIf="previewActive"></div>
+<div class="camera-container">
+  <div id="cameraPreview" class="preview-box"></div>
 
-  <div class="photo-controls">
-    <button mat-raised-button color="primary" (click)="takePhotoSystem()" [disabled]="previewActive">
-      <mat-icon>photo_camera</mat-icon> Системная камера
-    </button>
-    <button mat-stroked-button color="warn" (click)="stopPreview()" *ngIf="previewActive">
-      <mat-icon>stop</mat-icon> Выключить превью
-    </button>
-    <button mat-raised-button color="accent" (click)="captureFromPreview()" *ngIf="previewActive">
-      <mat-icon>camera</mat-icon> Сфотографировать
-    </button>
-  </div>
-
-  <mat-progress-bar *ngIf="uploadProgress !== null" [mode]="progressMode" [value]="uploadProgress"></mat-progress-bar>
-
-  <div class="last-shot" *ngIf="photoDataUrl">
-    <img [src]="photoDataUrl" alt="snapshot" />
-  </div>
-
-  <form [formGroup]="form" class="text-form">
-    <mat-form-field appearance="outline">
-      <mat-label>Описание</mat-label>
-      <textarea matInput formControlName="note"></textarea>
-      <button *ngIf="form.value.note" mat-icon-button matSuffix aria-label="Очистить" (click)="form.controls['note'].setValue('')">
-        <mat-icon>close</mat-icon>
-      </button>
-    </mat-form-field>
-
-    <div class="mic">
-      <button mat-icon-button color="primary"
-              matTooltip="Удерживайте для записи"
-              aria-label="Записать голос"
-              (mousedown)="startRecord($event)" (touchstart)="startRecord($event)"
-              (mouseup)="stopRecord()" (mouseleave)="stopRecord()" (touchend)="stopRecord()"
-              [class.recording]="!!recorder" [disabled]="transcribing">
-        <mat-icon>{{ recorder ? 'mic' : 'mic_none' }}</mat-icon>
-      </button>
-      <div class="hint" *ngIf="!recorder">Удерживайте для записи</div>
-      <div class="hint recording" *ngIf="recorder">Запись… отпустите, чтобы остановить</div>
+  <div class="preview-overlay" *ngIf="previewActive">
+    <div class="preview-hint">
+      <mat-icon>info</mat-icon>
+      <span>Наведите камеру на блюдо и нажмите на кнопку, чтобы сделать снимок.</span>
     </div>
+    <div class="preview-controls">
+      <button mat-mini-fab color="accent" (click)="openNoteDialog()" matTooltip="Добавить текст или голосовое описание" aria-label="Добавить описание">
+        <mat-icon>edit</mat-icon>
+      </button>
+      <button mat-fab color="primary" (click)="captureFromPreview()" matTooltip="Сделать фото" aria-label="Сделать фото">
+        <mat-icon>camera</mat-icon>
+      </button>
+      <button mat-mini-fab color="primary" (click)="takePhotoSystem()" matTooltip="Открыть системную камеру" aria-label="Системная камера">
+        <mat-icon>photo_camera</mat-icon>
+      </button>
+    </div>
+  </div>
 
-    <mat-progress-bar *ngIf="transcribing" mode="indeterminate"></mat-progress-bar>
+  <div class="preview-overlay inactive" *ngIf="!previewActive">
+    <div class="preview-hint">
+      <mat-icon>warning</mat-icon>
+      <span>Предпросмотр недоступен. Попробуйте включить его снова или воспользуйтесь системной камерой.</span>
+    </div>
+    <div class="preview-controls">
+      <button mat-raised-button color="primary" (click)="retryPreview()">
+        <mat-icon>autorenew</mat-icon>
+        Повторить попытку
+      </button>
+      <button mat-stroked-button color="primary" (click)="takePhotoSystem()">
+        <mat-icon>photo_camera</mat-icon>
+        Системная камера
+      </button>
+      <button mat-mini-fab color="accent" (click)="openNoteDialog()" matTooltip="Добавить текст или голосовое описание" aria-label="Добавить описание">
+        <mat-icon>edit</mat-icon>
+      </button>
+    </div>
+  </div>
+</div>
 
-    <button mat-flat-button color="primary" (click)="sendText()" [disabled]="!form.value.note.trim()">Отправить</button>
-  </form>
+<mat-progress-bar *ngIf="uploadProgress !== null" [mode]="progressMode" [value]="uploadProgress"></mat-progress-bar>
 
-  </mat-card>
+<div class="last-shot" *ngIf="photoDataUrl">
+  <img [src]="photoDataUrl" alt="snapshot" />
+</div>

--- a/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.scss
+++ b/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.scss
@@ -1,11 +1,81 @@
-﻿:host { display:block; }
-.preview-box { width:100%; height:360px; border-radius:12px; overflow:hidden; background:#000; margin-bottom:12px; }
-.photo-controls { display:flex; gap:8px; flex-wrap:wrap; margin-bottom:12px; }
-.last-shot img { width:100%; max-height:240px; object-fit:cover; border-radius:10px; margin-bottom:12px; }
+:host {
+  display: block;
+  min-height: 100vh;
+}
 
-.text-form { display:flex; flex-direction:column; gap:12px; }
-.mic { display:grid; justify-items:center; }
-.mic .hint { font-size:12px; opacity:.7; margin-top:2px; text-align:center; line-height:1.1; }
-.mic .hint.recording { opacity:.9; }
-.mic button.recording { animation:pulse 1s ease-in-out infinite; }
-@keyframes pulse { 0%{box-shadow:0 0 0 0 rgba(244,67,54,.45);} 70%{box-shadow:0 0 0 12px rgba(244,67,54,0);} 100%{box-shadow:0 0 0 0 rgba(244,67,54,0);} }
+.camera-container {
+  position: relative;
+  width: 100%;
+  height: calc(100vh - 64px);
+  max-height: 100vh;
+  background: #000;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.preview-box {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background: #000;
+}
+
+.preview-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 16px;
+  pointer-events: none;
+}
+
+.preview-overlay .preview-hint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  padding: 12px 16px;
+  border-radius: 12px;
+  max-width: 320px;
+  font-size: 14px;
+  line-height: 1.3;
+}
+
+.preview-overlay .preview-controls {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  pointer-events: auto;
+}
+
+.preview-overlay.inactive {
+  background: rgba(0, 0, 0, 0.75);
+}
+
+.preview-overlay.inactive .preview-hint {
+  background: rgba(255, 255, 255, 0.92);
+  color: #111;
+}
+
+.preview-overlay.inactive .preview-controls {
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+mat-progress-bar {
+  margin-top: 16px;
+}
+
+.last-shot {
+  margin-top: 16px;
+}
+
+.last-shot img {
+  width: 100%;
+  max-height: 320px;
+  object-fit: cover;
+  border-radius: 12px;
+}


### PR DESCRIPTION
## Summary
- launch the full screen camera preview on page entry, add overlay hints and fallback controls for the system camera
- move text and voice note capture into a standalone dialog component with proper snackbar handling and auto-close on success
- refresh page and dialog styling to support floating controls and voice recording states

## Testing
- npm test -- --watch=false *(fails: Chrome browser binary is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca559d62d08331a22e4f7710d9e26d