### PR TITLE
Ensure Angular build runs before static web asset processing

### DIFF
--- a/FoodBot/FoodBot.csproj
+++ b/FoodBot/FoodBot.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
   </ItemGroup>
 
-  <Target Name="BuildClientApp" BeforeTargets="Build">
+  <Target Name="BuildClientApp" BeforeTargets="Build;ProcessStaticWebAssets">
     <RemoveDir Directories="$(ProjectDir)wwwroot" />
     <Exec WorkingDirectory="../mobile/calorie-counter" Command="npm install" />
     <Exec WorkingDirectory="../mobile/calorie-counter" Command="npm run build -- --configuration production" />


### PR DESCRIPTION
## Summary
- ensure the client build target executes before both the build and static web asset processing phases so freshly generated Angular bundles are discovered by `dotnet publish`

## Testing
- not run (environment lacks .NET SDK)


------
https://chatgpt.com/codex/tasks/task_e_68ca68cd02e08331bb975955fc330e2c