### PR TITLE
Align history detail dialog styling with history page

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.html
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.html
@@ -1,20 +1,35 @@
 <div class="container">
+  <div class="header-row">
+    <span class="header-left">{{ time(data.item.createdAtUtc) }}</span>
+    <span class="dot">·</span>
+    <span class="header-right">{{ data.item.caloriesKcal ?? '—' }} ккал</span>
+  </div>
+
+  <div class="title" [title]="data.item.dishName || ''">
+    {{ data.item.dishName || 'Без названия' }}
+  </div>
+
+  <div class="chips">
+    <span class="chip">Б {{ data.item.proteinsG ?? '—' }}</span>
+    <span class="chip">Ж {{ data.item.fatsG ?? '—' }}</span>
+    <span class="chip">У {{ data.item.carbsG ?? '—' }}</span>
+    <span class="chip" *ngIf="data.item.weightG">⚖ {{ data.item.weightG }} г</span>
+  </div>
+
+  <div class="queued" *ngIf="data.item.updateQueued">Обновляется…</div>
+
   <img
     #photo
     *ngIf="data.item.hasImage && data.imageUrl"
     [src]="data.imageUrl"
-    alt="meal"
+    alt="Фото блюда"
     class="photo"
     (load)="fitDialog()"
   />
 
-  <div class="macros">
-    Б {{ data.item.proteinsG ?? '—' }} · Ж {{ data.item.fatsG ?? '—' }} · У {{ data.item.carbsG ?? '—' }} ·
-    {{ data.item.caloriesKcal ?? '—' }} ккал
-  </div>
-
   <div class="ingredients" *ngIf="data.item.ingredients?.length">
-    Ингредиенты: {{ data.item.ingredients.join(', ') }}
+    <span class="ingredients__icon" aria-hidden="true">🍣</span>
+    <span class="ingredients__text">{{ data.item.ingredients.join(', ') }}</span>
   </div>
 
   <!-- Компактная таблица состава -->
@@ -74,8 +89,17 @@
   </div>
 
   <div class="buttons">
-    <button mat-raised-button color="primary" (click)="openClarify()">Уточнить</button>
-    <button mat-button color="warn" (click)="remove()">Удалить</button>
-    <button mat-button (click)="dialogRef.close()">Закрыть</button>
+    <button mat-raised-button color="primary" (click)="openClarify()">
+      <mat-icon>edit</mat-icon>
+      <span>Уточнить</span>
+    </button>
+    <button mat-button color="warn" (click)="remove()">
+      <mat-icon>delete</mat-icon>
+      <span>Удалить</span>
+    </button>
+    <button mat-button (click)="dialogRef.close()">
+      <mat-icon>close</mat-icon>
+      <span>Закрыть</span>
+    </button>
   </div>
 </div>

--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
@@ -30,23 +30,74 @@
     /* overflow: auto; ← удалено */
   }
 
+
+.header-row {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  background: var(--mat-sys-surface, #fff);
+  box-shadow: 0 1px 0 rgba(0,0,0,.06);
+
+  font-size: 17px;
+  line-height: 1.25;
+  font-weight: 600;
+
+  .header-left  { opacity: .9; }
+  .header-right { opacity: .85; font-weight: 500; }
+  .dot { opacity: .5; }
+}
+
+.title {
+  font-weight: 600;
+  opacity: .92;
+  margin: 6px 0 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+
+  .chip {
+    font-size: 12px;
+    line-height: 18px;
+    padding: 0 8px;
+    border-radius: 999px;
+    background: rgba(0,0,0,.05);
+    white-space: nowrap;
+  }
+}
+
+.queued { font-size: 12px; color: #ff9800; }
+
 .photo {
   align-self: center;
   width: auto;
   height: auto;
   max-width: 100%;
   max-height: 55vh;
-  border-radius: 6px;
+  border-radius: 12px;
   object-fit: contain;
 }
 
-.macros { font-size: 13px; line-height: 1.2; }
 /* длинные ингредиенты будут переноситься */
 .ingredients {
+  margin-top: 6px;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
   font-size: 12.5px;
   line-height: 1.2;
   overflow-wrap: anywhere;
   word-break: break-word;
+
+  &__icon { opacity: .7; font-size: 14px; }
+  &__text { flex: 1; }
 }
 
 /* Таблица компактная, не на всю ширину */
@@ -80,4 +131,17 @@
   display: flex;
   justify-content: flex-end;
   gap: 6px;
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    line-height: 18px;
+  }
 }

--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
@@ -4,6 +4,7 @@ import { MatButtonModule } from "@angular/material/button";
 import { MatDialog, MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
 import { MatSnackBar, MatSnackBarModule } from "@angular/material/snack-bar";
 import { MatTableModule } from "@angular/material/table";
+import { MatIconModule } from "@angular/material/icon";
 import { FoodbotApiService } from "../../services/foodbot-api.service";
 import { MealListItem, ClarifyResult } from "../../services/foodbot-api.types";
 import { HistoryClarifyDialogComponent } from "./history-clarify.dialog";
@@ -16,7 +17,8 @@ import { HistoryClarifyDialogComponent } from "./history-clarify.dialog";
     MatButtonModule,
     MatDialogModule,
     MatSnackBarModule,
-    MatTableModule
+    MatTableModule,
+    MatIconModule
   ],
   templateUrl: './history-detail.dialog.html',
   styleUrls: ['./history-detail.dialog.scss']
@@ -49,6 +51,10 @@ export class HistoryDetailDialogComponent implements OnInit {
 
     // небольшая «пинок»-подстройка сразу после первой отрисовки
     this.fitDialog();
+  }
+
+  time(s: string) {
+    return new Date(s).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
   }
 
   /** Аккуратно подгоняет высоту диалога под контент */


### PR DESCRIPTION
## Summary
- restyled the history detail dialog to reuse the header, title, macro chips, and queued status from the history list cards
- show the meal name, time, and weight to match the information available on the history page
- added button icons for clarify/delete/close actions via MatIconModule

## Testing
- npm run build -- --output-path ../../tmp-build

------
https://chatgpt.com/codex/tasks/task_e_68cae87c34708331b3e47e6070a95e63