### PR TITLE
Adjust history detail dialog header layout

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.html
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.html
@@ -1,22 +1,7 @@
 <div class="container">
-  <div class="header-row">
-    <span class="header-left">{{ time(data.item.createdAtUtc) }}</span>
-    <span class="dot">·</span>
-    <span class="header-right">{{ data.item.caloriesKcal ?? '—' }} ккал</span>
-  </div>
-
-  <div class="title" [title]="data.item.dishName || ''">
+  <div class="header-row" [title]="data.item.dishName || ''">
     {{ data.item.dishName || 'Без названия' }}
   </div>
-
-  <div class="chips">
-    <span class="chip">Б {{ data.item.proteinsG ?? '—' }}</span>
-    <span class="chip">Ж {{ data.item.fatsG ?? '—' }}</span>
-    <span class="chip">У {{ data.item.carbsG ?? '—' }}</span>
-    <span class="chip" *ngIf="data.item.weightG">⚖ {{ data.item.weightG }} г</span>
-  </div>
-
-  <div class="queued" *ngIf="data.item.updateQueued">Обновляется…</div>
 
   <img
     #photo
@@ -26,6 +11,23 @@
     class="photo"
     (load)="fitDialog()"
   />
+
+  <div class="meta">
+    <div class="meta-row">
+      <span class="meta-left">{{ time(data.item.createdAtUtc) }}</span>
+      <span class="dot">·</span>
+      <span class="meta-right">{{ data.item.caloriesKcal ?? '—' }} ккал</span>
+    </div>
+
+    <div class="chips">
+      <span class="chip">Б {{ data.item.proteinsG ?? '—' }}</span>
+      <span class="chip">Ж {{ data.item.fatsG ?? '—' }}</span>
+      <span class="chip">У {{ data.item.carbsG ?? '—' }}</span>
+      <span class="chip" *ngIf="data.item.weightG">⚖ {{ data.item.weightG }} г</span>
+    </div>
+
+    <div class="queued" *ngIf="data.item.updateQueued">Обновляется…</div>
+  </div>
 
   <div class="ingredients" *ngIf="data.item.ingredients?.length">
     <span class="ingredients__icon" aria-hidden="true">🍣</span>

--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
@@ -32,31 +32,36 @@
 
 
 .header-row {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 6px;
-  padding: 6px 10px;
+  display: block;
+  padding: 8px 12px;
   border-radius: 10px;
   background: var(--mat-sys-surface, #fff);
   box-shadow: 0 1px 0 rgba(0,0,0,.06);
+  font-size: 18px;
+  line-height: 1.3;
+  font-weight: 600;
+  opacity: .95;
+  word-break: break-word;
+}
 
-  font-size: 17px;
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.meta-row {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 15px;
   line-height: 1.25;
-  font-weight: 600;
-
-  .header-left  { opacity: .9; }
-  .header-right { opacity: .85; font-weight: 500; }
-  .dot { opacity: .5; }
+  font-weight: 500;
 }
 
-.title {
-  font-weight: 600;
-  opacity: .92;
-  margin: 6px 0 2px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+.meta-left { opacity: .9; }
+.meta-right { opacity: .85; font-weight: 500; }
+.meta-row .dot { opacity: .5; }
 
 .chips {
   display: flex;


### PR DESCRIPTION
## Summary
- show the meal name in the history detail dialog header
- move time, calories, and nutrition chips beneath the photo with matching styles

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68caed0a91ac8331a0f0823fac9d9ce8