### PR TITLE
Update /add edit button to clarify latest meal

### DIFF
--- a/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.html
+++ b/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.html
@@ -7,7 +7,8 @@
       <span>Наведите камеру на блюдо и нажмите на кнопку, чтобы сделать снимок.</span>
     </div>
     <div class="preview-controls">
-      <button mat-mini-fab color="accent" (click)="openNoteDialog()" matTooltip="Добавить текст или голосовое описание" aria-label="Добавить описание">
+      <button mat-mini-fab color="accent" (click)="openClarifyDialog()" [disabled]="clarifyLoading"
+              matTooltip="Изменить время или уточнение последнего фото" aria-label="Редактировать уточнение">
         <mat-icon>edit</mat-icon>
       </button>
       <button mat-fab color="primary" (click)="captureFromPreview()" matTooltip="Сделать фото" aria-label="Сделать фото">
@@ -33,7 +34,8 @@
         <mat-icon>photo_camera</mat-icon>
         Системная камера
       </button>
-      <button mat-mini-fab color="accent" (click)="openNoteDialog()" matTooltip="Добавить текст или голосовое описание" aria-label="Добавить описание">
+      <button mat-mini-fab color="accent" (click)="openClarifyDialog()" [disabled]="clarifyLoading"
+              matTooltip="Изменить время или уточнение последнего фото" aria-label="Редактировать уточнение">
         <mat-icon>edit</mat-icon>
       </button>
     </div>


### PR DESCRIPTION
## Summary
- replace the /add page edit action with a clarification dialog for the most recent meal
- keep track of the latest processed meal via API and SignalR to edit note or meal time after a photo upload
- handle pending uploads so the button warns while recognition is still running and preserve the menu option for text-only entries

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc2d71ad7c8331bd56fca2bdf28a90