### PR TITLE
Add clarification preview for recent meal photo

### DIFF
--- a/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.html
+++ b/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.html
@@ -53,6 +53,18 @@
     </div>
 
     <mat-progress-bar *ngIf="transcribing" mode="indeterminate"></mat-progress-bar>
+
+    <div class="preview" *ngIf="previewNote || previewTime">
+      <div class="preview__title">Будет отправлено:</div>
+      <div class="preview__row" *ngIf="previewNote">
+        <span class="preview__label">Текст:</span>
+        <span class="preview__value">{{ previewNote }}</span>
+      </div>
+      <div class="preview__row" *ngIf="previewTime as previewTimeValue">
+        <span class="preview__label">Время:</span>
+        <span class="preview__value">{{ previewTimeValue | date: 'HH:mm, d MMMM' }}</span>
+      </div>
+    </div>
   </div>
 
   <div mat-dialog-actions class="actions" [class.actions--history]="isHistoryClarify">

--- a/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.scss
+++ b/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.scss
@@ -82,6 +82,38 @@
   flex: 1;
 }
 
+.preview {
+  border-radius: 12px;
+  background: #f5f7fb;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 14px;
+  line-height: 1.4;
+  color: #1f2937;
+}
+
+.preview__title {
+  font-weight: 600;
+}
+
+.preview__row {
+  display: flex;
+  gap: 8px;
+}
+
+.preview__label {
+  font-weight: 600;
+  color: #111827;
+}
+
+.preview__value {
+  flex: 1;
+  color: #374151;
+  word-break: break-word;
+}
+
 @media (min-width: 560px) {
   .dialog-content {
     display: grid;
@@ -100,5 +132,9 @@
 
   .mic.inline {
     justify-items: start;
+  }
+
+  .preview {
+    grid-column: 1 / -1;
   }
 }

--- a/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.html
+++ b/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.html
@@ -47,3 +47,23 @@
 <div class="last-shot" *ngIf="photoDataUrl">
   <img [src]="photoDataUrl" alt="snapshot" />
 </div>
+
+<div class="clarify-preview" *ngIf="clarifyPreview as preview">
+  <div class="clarify-preview__header">
+    <mat-icon>edit_note</mat-icon>
+    <span>Уточнение к фото</span>
+  </div>
+  <div class="clarify-preview__body">
+    <div class="clarify-preview__row" *ngIf="preview.note">
+      <span class="clarify-preview__label">Текст:</span>
+      <span class="clarify-preview__value">{{ preview.note }}</span>
+    </div>
+    <div class="clarify-preview__row">
+      <span class="clarify-preview__label">Время:</span>
+      <span class="clarify-preview__value">{{ preview.timeUtc | date: 'HH:mm, d MMMM' }}</span>
+    </div>
+    <div class="clarify-preview__queued" *ngIf="preview.queued">
+      Отправлено на уточнение, ожидает обработки
+    </div>
+  </div>
+</div>

--- a/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.scss
+++ b/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.scss
@@ -86,3 +86,52 @@ mat-progress-bar {
   object-fit: cover;
   border-radius: 12px;
 }
+
+.clarify-preview {
+  width: min(100%, 520px);
+  margin: 0 auto;
+  padding: 16px;
+  border-radius: 12px;
+  background: #f5f7fb;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: #1f2937;
+}
+
+.clarify-preview__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.clarify-preview__body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.clarify-preview__row {
+  display: flex;
+  gap: 8px;
+}
+
+.clarify-preview__label {
+  font-weight: 600;
+  color: #111827;
+}
+
+.clarify-preview__value {
+  flex: 1;
+  color: #374151;
+  word-break: break-word;
+}
+
+.clarify-preview__queued {
+  font-size: 13px;
+  color: #1d4ed8;
+}


### PR DESCRIPTION
## Summary
- surface the last clarification note and time on the add-meal page with a dedicated preview panel
- track clarification submissions on the add page to keep queued state and timestamps in sync
- show a live summary inside the voice note dialog and include queued time metadata when sending clarifications

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc3c515ad083318db5d98dd9cefd07