### PR TITLE
Add note/time support for meal photo upload

### DIFF
--- a/FoodBot/Data/PendingMeal.cs
+++ b/FoodBot/Data/PendingMeal.cs
@@ -14,5 +14,6 @@ public class PendingMeal
     public bool GenerateImage { get; set; }
     public int Attempts { get; set; }
     public DateTimeOffset? DesiredMealTimeUtc { get; set; }
+    public string? ClarifyNote { get; set; }
 }
 

--- a/FoodBot/Migrations/20250919120000_pendingmeal_clarifynote.Designer.cs
+++ b/FoodBot/Migrations/20250919120000_pendingmeal_clarifynote.Designer.cs
@@ -4,6 +4,7 @@ using FoodBot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FoodBot.Migrations
 {
     [DbContext(typeof(BotDbContext))]
-    partial class BotDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250919120000_pendingmeal_clarifynote")]
+    partial class pendingmeal_clarifynote : Migration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FoodBot/Migrations/20250919120000_pendingmeal_clarifynote.cs
+++ b/FoodBot/Migrations/20250919120000_pendingmeal_clarifynote.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FoodBot.Migrations
+{
+    /// <inheritdoc />
+    public partial class pendingmeal_clarifynote : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ClarifyNote",
+                table: "PendingMeals",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ClarifyNote",
+                table: "PendingMeals");
+        }
+    }
+}

--- a/FoodBot/Services/Meals/IMealService.cs
+++ b/FoodBot/Services/Meals/IMealService.cs
@@ -8,7 +8,7 @@ public interface IMealService
     Task<MealListResult> ListAsync(long chatId, int limit, int offset, CancellationToken ct);
     Task<MealDetails?> GetDetailsAsync(long chatId, int id, CancellationToken ct);
     Task<(byte[] bytes, string mime)?> GetImageAsync(long chatId, int id, CancellationToken ct);
-    Task QueueImageAsync(long chatId, byte[] bytes, string fileMime, CancellationToken ct);
+    Task QueueImageAsync(long chatId, byte[] bytes, string fileMime, string? note, DateTimeOffset? desiredTime, CancellationToken ct);
     Task QueueTextAsync(long chatId, string description, bool generateImage, DateTimeOffset? desiredTime, CancellationToken ct);
     Task<ClarifyTextResult?> ClarifyTextAsync(long chatId, int id, string? note, DateTimeOffset? time, CancellationToken ct);
     Task<bool> DeleteAsync(long chatId, int id, CancellationToken ct);

--- a/FoodBot/Services/Meals/MealService.cs
+++ b/FoodBot/Services/Meals/MealService.cs
@@ -124,9 +124,10 @@ public sealed class MealService : IMealService
         return new(m.ImageBytes, mime);
     }
 
-    public Task QueueImageAsync(long chatId, byte[] bytes, string fileMime, CancellationToken ct)
+    public Task QueueImageAsync(long chatId, byte[] bytes, string fileMime, string? note, DateTimeOffset? desiredTime, CancellationToken ct)
     {
         var utcNow = DateTimeOffset.UtcNow;
+        var desired = (desiredTime ?? utcNow).ToUniversalTime();
         var pending = new PendingMeal
         {
             ChatId = chatId,
@@ -134,7 +135,8 @@ public sealed class MealService : IMealService
             FileMime = fileMime,
             ImageBytes = bytes,
             Attempts = 0,
-            DesiredMealTimeUtc = utcNow
+            DesiredMealTimeUtc = desired,
+            ClarifyNote = string.IsNullOrWhiteSpace(note) ? null : note.Trim()
         };
         return _repo.QueuePendingMealAsync(pending, ct);
     }

--- a/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.html
+++ b/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.html
@@ -7,6 +7,10 @@
       <span>Наведите камеру на блюдо и нажмите на кнопку, чтобы сделать снимок.</span>
     </div>
     <div class="preview-controls">
+      <button mat-mini-fab color="accent" (click)="openNextClarifyDialog()"
+              matTooltip="Добавить уточнение к следующему фото" aria-label="Уточнение к следующему фото">
+        <mat-icon>note_add</mat-icon>
+      </button>
       <button mat-mini-fab color="accent" (click)="openClarifyDialog()" [disabled]="clarifyLoading"
               matTooltip="Изменить время или уточнение последнего фото" aria-label="Редактировать уточнение">
         <mat-icon>edit</mat-icon>
@@ -26,6 +30,10 @@
       <span>Предпросмотр недоступен. Попробуйте включить его снова или воспользуйтесь системной камерой.</span>
     </div>
     <div class="preview-controls">
+      <button mat-mini-fab color="accent" (click)="openNextClarifyDialog()"
+              matTooltip="Добавить уточнение к следующему фото" aria-label="Уточнение к следующему фото">
+        <mat-icon>note_add</mat-icon>
+      </button>
       <button mat-raised-button color="primary" (click)="retryPreview()">
         <mat-icon>autorenew</mat-icon>
         Повторить попытку
@@ -46,6 +54,26 @@
 
 <div class="last-shot" *ngIf="photoDataUrl">
   <img [src]="photoDataUrl" alt="snapshot" />
+</div>
+
+<div class="clarify-preview" *ngIf="nextClarifyDraft as draft">
+  <div class="clarify-preview__header">
+    <mat-icon>note_add</mat-icon>
+    <span>Уточнение к следующему фото</span>
+  </div>
+  <div class="clarify-preview__body">
+    <div class="clarify-preview__row" *ngIf="draft.note">
+      <span class="clarify-preview__label">Текст:</span>
+      <span class="clarify-preview__value">{{ draft.note }}</span>
+    </div>
+    <div class="clarify-preview__row" *ngIf="draft.time">
+      <span class="clarify-preview__label">Время:</span>
+      <span class="clarify-preview__value">{{ draft.time | date: 'HH:mm, d MMMM' }}</span>
+    </div>
+    <div class="clarify-preview__queued">
+      Будет приложено к следующему фото
+    </div>
+  </div>
 </div>
 
 <div class="clarify-preview" *ngIf="clarifyPreview as preview">

--- a/mobile/calorie-counter/src/app/services/foodbot-api.service.ts
+++ b/mobile/calorie-counter/src/app/services/foodbot-api.service.ts
@@ -33,9 +33,11 @@ export class FoodbotApiService {
   }
 
   // Загрузка фото
-  uploadPhoto(file: File): Observable<HttpEvent<{ queued: boolean }>> {
+  uploadPhoto(file: File, note?: string, time?: string): Observable<HttpEvent<{ queued: boolean }>> {
     const form = new FormData();
     form.append("image", file, file.name);
+    if (note) form.append("note", note);
+    if (time) form.append("time", time);
     return this.http.post<{ queued: boolean }>(
       `${this.baseUrl}/api/meals/upload`,
       form,


### PR DESCRIPTION
## Summary
- allow `/api/meals/upload` to accept optional clarifying note and meal time when queueing photo uploads
- persist the optional note/time on pending meals and apply them during photo processing, including a migration for the new column
- extend the mobile add-meal flow to collect note/time before sending a photo and deliver them in the same request

## Testing
- npm run build
- dotnet test *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccad7c2b5083318bcc5f01a86ffe17