### PR TITLE
feat: extract voice input panel component

### DIFF
--- a/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.html
+++ b/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.html
@@ -1,0 +1,41 @@
+<div class="voice-input-panel">
+  <mat-form-field appearance="outline" class="voice-input-panel__field">
+    <mat-label>{{ label }}</mat-label>
+    <textarea matInput
+              cdkTextareaAutosize
+              [cdkAutosizeMinRows]="minRows"
+              [cdkAutosizeMaxRows]="maxRows"
+              [placeholder]="placeholder"
+              [formControl]="control"></textarea>
+    <button *ngIf="hasValue"
+            mat-icon-button
+            matSuffix
+            type="button"
+            aria-label="Очистить"
+            (click)="onClear($event)">
+      <mat-icon>close</mat-icon>
+    </button>
+  </mat-form-field>
+
+  <button type="button"
+          mat-mini-fab
+          color="primary"
+          class="voice-input-panel__mic"
+          [class.voice-input-panel__mic--recording]="isRecording"
+          [disabled]="disabled"
+          aria-label="Записать голос"
+          [matTooltip]="idleHint"
+          (mousedown)="onPress($event)"
+          (touchstart)="onPress($event)"
+          (mouseup)="onRelease()"
+          (mouseleave)="onRelease()"
+          (touchend)="onRelease()"
+          (touchcancel)="onRelease()">
+    <mat-icon>{{ isRecording ? 'mic' : 'mic_none' }}</mat-icon>
+  </button>
+
+  <div *ngIf="showHints" class="voice-input-panel__hints">
+    <div class="voice-input-panel__hint" *ngIf="!isRecording">{{ idleHint }}</div>
+    <div class="voice-input-panel__hint voice-input-panel__hint--recording" *ngIf="isRecording">{{ recordingHint }}</div>
+  </div>
+</div>

--- a/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.scss
+++ b/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.scss
@@ -1,0 +1,58 @@
+.voice-input-panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.voice-input-panel__field {
+  width: 100%;
+}
+
+.voice-input-panel__field textarea {
+  min-height: 116px;
+  padding-right: 56px;
+}
+
+.voice-input-panel__mic {
+  position: absolute;
+  right: 16px;
+  bottom: 24px;
+  z-index: 2;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.voice-input-panel__mic--recording {
+  animation: pulse 1s ease-in-out infinite;
+}
+
+.voice-input-panel__hints {
+  font-size: 12px;
+  opacity: 0.7;
+  line-height: 1.2;
+}
+
+.voice-input-panel__hint--recording {
+  opacity: 0.9;
+}
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(244, 67, 54, 0.45);
+    transform: scale(1);
+  }
+  70% {
+    box-shadow: 0 0 0 12px rgba(244, 67, 54, 0);
+    transform: scale(1.05);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(244, 67, 54, 0);
+    transform: scale(1);
+  }
+}
+
+@media (min-width: 560px) {
+  .voice-input-panel__mic {
+    bottom: 32px;
+  }
+}

--- a/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.ts
+++ b/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.ts
@@ -1,0 +1,62 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatInputModule } from "@angular/material/input";
+import { MatIconModule } from "@angular/material/icon";
+import { MatButtonModule } from "@angular/material/button";
+import { MatTooltipModule } from "@angular/material/tooltip";
+import { TextFieldModule } from "@angular/cdk/text-field";
+import { FormControl, ReactiveFormsModule } from "@angular/forms";
+
+@Component({
+  selector: "app-voice-input-panel",
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatButtonModule,
+    MatTooltipModule,
+    TextFieldModule
+  ],
+  templateUrl: "./voice-input-panel.component.html",
+  styleUrls: ["./voice-input-panel.component.scss"],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class VoiceInputPanelComponent {
+  @Input() label = "";
+  @Input() placeholder = "";
+  @Input() minRows = 4;
+  @Input() maxRows = 12;
+  @Input() control!: FormControl<string | null>;
+  @Input() isRecording = false;
+  @Input() disabled = false;
+  @Input() idleHint = "Удерживайте для записи";
+  @Input() recordingHint = "Запись… отпустите, чтобы остановить";
+  @Input() showHints = true;
+
+  @Output() cleared = new EventEmitter<void>();
+  @Output() startRecord = new EventEmitter<Event>();
+  @Output() stopRecord = new EventEmitter<void>();
+
+  onPress(event: Event) {
+    event.preventDefault();
+    this.startRecord.emit(event);
+  }
+
+  onRelease() {
+    this.stopRecord.emit();
+  }
+
+  onClear(event: MouseEvent) {
+    event.preventDefault();
+    this.cleared.emit();
+  }
+
+  get hasValue(): boolean {
+    const value = this.control.value;
+    return typeof value === "string" ? value.length > 0 : !!value;
+  }
+}

--- a/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.html
+++ b/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.html
@@ -4,18 +4,20 @@
   </h2>
 
   <div mat-dialog-content class="dialog-content">
-    <mat-form-field appearance="outline" class="note-field">
-      <mat-label>{{ isHistoryClarify ? 'Текст' : 'Описание' }}</mat-label>
-      <textarea matInput
-                formControlName="note"
-                cdkTextareaAutosize
-                [attr.rows]="isHistoryClarify ? null : 4"
-                cdkAutosizeMinRows="4"
-                cdkAutosizeMaxRows="12"></textarea>
-      <button *ngIf="noteControl?.value" mat-icon-button matSuffix aria-label="Очистить" (click)="clearNote()">
-        <mat-icon>close</mat-icon>
-      </button>
-    </mat-form-field>
+    <app-voice-input-panel
+      class="voice-input"
+      [label]="isHistoryClarify ? 'Текст' : 'Описание'"
+      [control]="noteControl!"
+      [isRecording]="!!recorder"
+      [disabled]="transcribing"
+      [minRows]="4"
+      [maxRows]="12"
+      [idleHint]="'Удерживайте для записи'"
+      [recordingHint]="'Запись… отпустите, чтобы остановить'"
+      (cleared)="clearNote()"
+      (startRecord)="startRecord($event)"
+      (stopRecord)="stopRecord()">
+    </app-voice-input-panel>
 
     <mat-form-field appearance="outline" class="time-field">
       <mat-label>{{ isHistoryClarify ? 'Время' : 'Дата и время' }}</mat-label>
@@ -24,33 +26,6 @@
              formControlName="timestamp" />
       <mat-icon *ngIf="isHistoryClarify" matSuffix>schedule</mat-icon>
     </mat-form-field>
-
-    <div class="mic" [class.inline]="isHistoryClarify">
-      <button *ngIf="!isHistoryClarify"
-              mat-fab color="primary"
-              matTooltip="Удерживайте для записи"
-              aria-label="Записать голос"
-              (mousedown)="startRecord($event)" (touchstart)="startRecord($event)"
-              (mouseup)="stopRecord()" (mouseleave)="stopRecord()"
-              (touchend)="stopRecord()" (touchcancel)="stopRecord()"
-              [class.recording]="!!recorder" [disabled]="transcribing">
-        <mat-icon>{{ recorder ? 'mic' : 'mic_none' }}</mat-icon>
-      </button>
-
-      <button *ngIf="isHistoryClarify"
-              mat-icon-button color="primary"
-              matTooltip="Удерживайте для записи"
-              aria-label="Записать голос"
-              (mousedown)="startRecord($event)" (touchstart)="startRecord($event)"
-              (mouseup)="stopRecord()" (mouseleave)="stopRecord()"
-              (touchend)="stopRecord()" (touchcancel)="stopRecord()"
-              [class.recording]="!!recorder" [disabled]="transcribing">
-        <mat-icon>{{ recorder ? 'mic' : 'mic_none' }}</mat-icon>
-      </button>
-
-      <div class="hint" *ngIf="!recorder">Удерживайте для записи</div>
-      <div class="hint recording" *ngIf="recorder">Запись… отпустите, чтобы остановить</div>
-    </div>
 
     <mat-progress-bar *ngIf="transcribing" mode="indeterminate"></mat-progress-bar>
 

--- a/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.scss
+++ b/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.scss
@@ -21,49 +21,12 @@
   gap: 16px;
 }
 
-.note-field textarea {
-  min-height: 116px;
-}
-
 .time-field {
   width: 100%;
 }
 
-.mic {
-  display: grid;
-  justify-items: center;
-  gap: 6px;
-}
-
-.mic.inline {
-  justify-items: center;
-}
-
-.mic .hint {
-  font-size: 12px;
-  opacity: 0.7;
-  text-align: center;
-  line-height: 1.2;
-}
-
-.mic .hint.recording {
-  opacity: 0.9;
-}
-
-.mic button.recording {
-  animation: pulse 1s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0% {
-    box-shadow: 0 0 0 0 rgba(244, 67, 54, 0.45);
-  }
-  70% {
-    box-shadow: 0 0 0 12px rgba(244, 67, 54, 0);
-  }
-  100% {
-    box-shadow: 0 0 0 0 rgba(244, 67, 54, 0);
-  }
+.voice-input {
+  display: block;
 }
 
 .actions {
@@ -122,16 +85,12 @@
     align-items: start;
   }
 
-  .note-field {
+  .voice-input {
     grid-column: 1 / -1;
   }
 
   .time-field {
     width: 200px;
-  }
-
-  .mic.inline {
-    justify-items: start;
   }
 
   .preview {

--- a/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.ts
+++ b/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, OnDestroy } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { FormBuilder, FormGroup, ReactiveFormsModule } from "@angular/forms";
+import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
 import { MatButtonModule } from "@angular/material/button";
 import { MatDialog, MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
 import { MatFormFieldModule } from "@angular/material/form-field";
@@ -8,13 +8,12 @@ import { MatIconModule } from "@angular/material/icon";
 import { MatInputModule } from "@angular/material/input";
 import { MatProgressBarModule } from "@angular/material/progress-bar";
 import { MatSnackBar, MatSnackBarModule } from "@angular/material/snack-bar";
-import { MatTooltipModule } from "@angular/material/tooltip";
-import { TextFieldModule } from "@angular/cdk/text-field";
 import { firstValueFrom } from "rxjs";
 
 import { FoodbotApiService } from "../../services/foodbot-api.service";
 import { ClarifyResult } from "../../services/foodbot-api.types";
 import { ConfirmDialogComponent, ConfirmDialogData } from "../confirm-dialog/confirm-dialog.component";
+import { VoiceInputPanelComponent } from "../voice-input-panel/voice-input-panel.component";
 
 type AddMealVoiceNoteData = { title: string; kind: "addMeal" };
 type HistoryVoiceNoteData = { title: string; kind: "historyClarify"; mealId: number; createdAtUtc: string; note?: string };
@@ -29,8 +28,8 @@ export type VoiceNoteDialogData = AddMealVoiceNoteData | HistoryVoiceNoteData | 
     CommonModule,
     ReactiveFormsModule,
     MatButtonModule, MatDialogModule, MatFormFieldModule,
-    MatIconModule, MatInputModule, MatProgressBarModule, MatSnackBarModule, MatTooltipModule,
-    TextFieldModule
+    MatIconModule, MatInputModule, MatProgressBarModule, MatSnackBarModule,
+    VoiceInputPanelComponent
   ],
   templateUrl: "./voice-note-dialog.component.html",
   styleUrls: ["./voice-note-dialog.component.scss"]
@@ -86,8 +85,8 @@ export class VoiceNoteDialogComponent implements OnDestroy {
     }
   }
 
-  get noteControl() {
-    return this.form.get("note");
+  get noteControl(): FormControl<string | null> | null {
+    return this.form.get("note") as FormControl<string | null> | null;
   }
 
   get timestampControl() {


### PR DESCRIPTION
## Summary
- add a reusable voice-input panel component with integrated textarea, microphone button, and hints
- refactor the voice note dialog to consume the new component and simplify the layout styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd2b0488988331a4bfc1bd1591a359