### PR TITLE
Rework voice note dialog microphone controls

### DIFF
--- a/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.html
+++ b/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.html
@@ -4,20 +4,45 @@
   </h2>
 
   <div mat-dialog-content class="dialog-content">
-    <app-voice-input-panel
-      class="voice-input"
-      [label]="isHistoryClarify ? 'Текст' : 'Описание'"
-      [control]="noteControl!"
-      [isRecording]="!!recorder"
-      [disabled]="transcribing"
-      [minRows]="4"
-      [maxRows]="12"
-      [idleHint]="'Удерживайте для записи'"
-      [recordingHint]="'Запись… отпустите, чтобы остановить'"
-      (cleared)="clearNote()"
-      (startRecord)="startRecord($event)"
-      (stopRecord)="stopRecord()">
-    </app-voice-input-panel>
+    <div class="note-field">
+      <mat-form-field appearance="outline" class="note-field__form">
+        <mat-label>{{ isHistoryClarify ? 'Текст' : 'Описание' }}</mat-label>
+        <textarea matInput
+                  cdkTextareaAutosize
+                  [cdkAutosizeMinRows]="4"
+                  [cdkAutosizeMaxRows]="12"
+                  [disabled]="transcribing"
+                  [formControl]="noteControl!"></textarea>
+        <button *ngIf="hasNoteValue"
+                mat-icon-button
+                matSuffix
+                type="button"
+                aria-label="Очистить"
+                (click)="clearNote()">
+          <mat-icon>close</mat-icon>
+        </button>
+      </mat-form-field>
+
+      <button type="button"
+              class="note-field__mic-button"
+              [class.note-field__mic-button--recording]="isRecording"
+              [disabled]="transcribing"
+              aria-label="Записать голос"
+              [matTooltip]="micTooltip"
+              (mousedown)="startRecord($event)"
+              (touchstart)="startRecord($event)"
+              (mouseup)="stopRecord()"
+              (mouseleave)="stopRecord()"
+              (touchend)="stopRecord()"
+              (touchcancel)="stopRecord()">
+        <mat-icon>{{ isRecording ? 'mic' : 'mic_none' }}</mat-icon>
+      </button>
+
+      <div class="note-field__hints">
+        <div class="note-field__hint" *ngIf="!isRecording">{{ idleHint }}</div>
+        <div class="note-field__hint note-field__hint--recording" *ngIf="isRecording">{{ recordingHint }}</div>
+      </div>
+    </div>
 
     <mat-form-field appearance="outline" class="time-field">
       <mat-label>{{ isHistoryClarify ? 'Время' : 'Дата и время' }}</mat-label>

--- a/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.scss
+++ b/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.scss
@@ -25,8 +25,69 @@
   width: 100%;
 }
 
-.voice-input {
-  display: block;
+
+.note-field {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.note-field__form {
+  width: 100%;
+}
+
+.note-field__form textarea {
+  min-height: 116px;
+  padding-right: 96px;
+  padding-bottom: 56px;
+}
+
+.note-field__mic-button {
+  position: absolute;
+  right: 28px;
+  bottom: 28px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 2px solid #111827;
+  background: transparent;
+  color: #111827;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.note-field__mic-button:hover:not(:disabled) {
+  transform: scale(1.05);
+}
+
+.note-field__mic-button:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.note-field__mic-button--recording {
+  border-color: #f44336;
+  color: #f44336;
+}
+
+.note-field__mic-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.note-field__hints {
+  font-size: 12px;
+  opacity: 0.75;
+  line-height: 1.2;
+  min-height: 18px;
+}
+
+.note-field__hint--recording {
+  color: #f44336;
+  opacity: 0.85;
 }
 
 .actions {
@@ -85,7 +146,7 @@
     align-items: start;
   }
 
-  .voice-input {
+  .note-field {
     grid-column: 1 / -1;
   }
 

--- a/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.ts
+++ b/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.ts
@@ -8,12 +8,13 @@ import { MatIconModule } from "@angular/material/icon";
 import { MatInputModule } from "@angular/material/input";
 import { MatProgressBarModule } from "@angular/material/progress-bar";
 import { MatSnackBar, MatSnackBarModule } from "@angular/material/snack-bar";
+import { MatTooltipModule } from "@angular/material/tooltip";
+import { TextFieldModule } from "@angular/cdk/text-field";
 import { firstValueFrom } from "rxjs";
 
 import { FoodbotApiService } from "../../services/foodbot-api.service";
 import { ClarifyResult } from "../../services/foodbot-api.types";
 import { ConfirmDialogComponent, ConfirmDialogData } from "../confirm-dialog/confirm-dialog.component";
-import { VoiceInputPanelComponent } from "../voice-input-panel/voice-input-panel.component";
 
 type AddMealVoiceNoteData = { title: string; kind: "addMeal" };
 type HistoryVoiceNoteData = { title: string; kind: "historyClarify"; mealId: number; createdAtUtc: string; note?: string };
@@ -27,9 +28,15 @@ export type VoiceNoteDialogData = AddMealVoiceNoteData | HistoryVoiceNoteData | 
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    MatButtonModule, MatDialogModule, MatFormFieldModule,
-    MatIconModule, MatInputModule, MatProgressBarModule, MatSnackBarModule,
-    VoiceInputPanelComponent
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatProgressBarModule,
+    MatSnackBarModule,
+    MatTooltipModule,
+    TextFieldModule
   ],
   templateUrl: "./voice-note-dialog.component.html",
   styleUrls: ["./voice-note-dialog.component.scss"]
@@ -45,6 +52,8 @@ export class VoiceNoteDialogComponent implements OnDestroy {
   private initialNote?: string;
   private historyData?: HistoryVoiceNoteData;
   private readonly mode: VoiceNoteDialogData["kind"];
+  readonly idleHint = "Удерживайте для записи";
+  readonly recordingHint = "Запись… отпустите, чтобы остановить";
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: VoiceNoteDialogData,
@@ -95,6 +104,22 @@ export class VoiceNoteDialogComponent implements OnDestroy {
 
   get isHistoryClarify(): boolean {
     return !!this.historyData;
+  }
+
+  get isRecording(): boolean {
+    return !!this.recorder;
+  }
+
+  get hasNoteValue(): boolean {
+    const value = this.noteControl?.value;
+    if (typeof value === "string") {
+      return value.trim().length > 0;
+    }
+    return !!value;
+  }
+
+  get micTooltip(): string {
+    return this.isRecording ? this.recordingHint : this.idleHint;
   }
 
   get canSend(): boolean {


### PR DESCRIPTION
## Summary
- inline the voice note text area and microphone controls directly inside the dialog component
- add recording state helpers to manage tooltip text and note clearing without external emitters
- restyle the microphone button to sit inside the input panel with a bordered appearance and updated hints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd2f5deb608331b8e603aafba59086