### PR TITLE
Move voice transcription handling into voice input panel

### DIFF
--- a/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.html
+++ b/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.html
@@ -1,6 +1,6 @@
 <div class="chatgpt-input"
      [class.chatgpt-input--recording]="isRecording"
-     [class.chatgpt-input--disabled]="disabled">
+     [class.chatgpt-input--disabled]="isMicDisabled">
 
   <textarea
     class="chatgpt-input__textarea"
@@ -25,7 +25,7 @@
   <button type="button"
           class="chatgpt-input__mic"
           mat-icon-button
-          [disabled]="disabled"
+          [disabled]="isMicDisabled"
           [matTooltip]="idleHint"
           aria-label="Записать голос"
           (mousedown)="onPress($event)"

--- a/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.ts
+++ b/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from "@angular/core";
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, Output } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
@@ -7,6 +7,10 @@ import { MatButtonModule } from "@angular/material/button";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { TextFieldModule } from "@angular/cdk/text-field";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
+import { MatSnackBar } from "@angular/material/snack-bar";
+import { firstValueFrom } from "rxjs";
+
+import { FoodbotApiService } from "../../services/foodbot-api.service";
 
 @Component({
   selector: "app-voice-input-panel",
@@ -25,29 +29,35 @@ import { FormControl, ReactiveFormsModule } from "@angular/forms";
   styleUrls: ["./voice-input-panel.component.scss"],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class VoiceInputPanelComponent {
+export class VoiceInputPanelComponent implements OnDestroy {
   @Input() label = "";
   @Input() placeholder = "";
   @Input() minRows = 4;
   @Input() maxRows = 12;
   @Input() control!: FormControl<string | null>;
-  @Input() isRecording = false;
   @Input() disabled = false;
   @Input() idleHint = "Удерживайте для записи";
   @Input() recordingHint = "Запись… отпустите, чтобы остановить";
   @Input() showHints = true;
 
   @Output() cleared = new EventEmitter<void>();
-  @Output() startRecord = new EventEmitter<Event>();
-  @Output() stopRecord = new EventEmitter<void>();
+  @Output() transcribingChange = new EventEmitter<boolean>();
+
+  isRecording = false;
+  protected transcribing = false;
+
+  private recorder?: MediaRecorder;
+  private chunks: Blob[] = [];
+
+  constructor(private api: FoodbotApiService, private snack: MatSnackBar) {}
 
   onPress(event: Event) {
     event.preventDefault();
-    this.startRecord.emit(event);
+    void this.startRecording();
   }
 
   onRelease() {
-    this.stopRecord.emit();
+    void this.stopRecording();
   }
 
   onClear(event: MouseEvent) {
@@ -55,8 +65,88 @@ export class VoiceInputPanelComponent {
     this.cleared.emit();
   }
 
+  get isMicDisabled(): boolean {
+    return this.disabled || this.transcribing;
+  }
+
   get hasValue(): boolean {
     const value = this.control.value;
     return typeof value === "string" ? value.length > 0 : !!value;
+  }
+
+  ngOnDestroy() {
+    if (this.recorder && this.recorder.state !== "inactive") {
+      try {
+        this.recorder.stop();
+      } catch {
+        // ignore
+      }
+    }
+    this.recorder = undefined;
+    this.chunks = [];
+    this.setTranscribing(false);
+    this.isRecording = false;
+  }
+
+  private async startRecording() {
+    if (this.isMicDisabled || this.recorder) return;
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      this.chunks = [];
+      const recorder = new MediaRecorder(stream);
+      recorder.addEventListener(
+        "dataavailable",
+        event => {
+          if (event.data.size > 0) this.chunks.push(event.data);
+        }
+      );
+      recorder.addEventListener(
+        "stop",
+        () => {
+          stream.getTracks().forEach(track => track.stop());
+          this.isRecording = false;
+        },
+        { once: true }
+      );
+      recorder.start();
+      this.recorder = recorder;
+      this.isRecording = true;
+    } catch {
+      this.recorder = undefined;
+      this.isRecording = false;
+      this.snack.open("Не удалось получить доступ к микрофону", "OK", { duration: 1500 });
+    }
+  }
+
+  private async stopRecording() {
+    const recorder = this.recorder;
+    if (!recorder) return;
+    this.recorder = undefined;
+    const stopped = new Promise<void>(resolve =>
+      recorder.addEventListener("stop", () => resolve(), { once: true })
+    );
+    recorder.stop();
+    await stopped;
+    const chunks = this.chunks.slice();
+    this.chunks = [];
+    if (!chunks.length) return;
+
+    this.setTranscribing(true);
+    try {
+      const blob = new Blob(chunks, { type: "audio/webm" });
+      const file = new File([blob], "voice.webm", { type: blob.type });
+      const result = await firstValueFrom(this.api.transcribeVoice(file));
+      if (result.text) this.control?.setValue(result.text);
+    } catch {
+      this.snack.open("Не удалось распознать речь", "OK", { duration: 1500 });
+    } finally {
+      this.setTranscribing(false);
+    }
+  }
+
+  private setTranscribing(value: boolean) {
+    if (this.transcribing === value) return;
+    this.transcribing = value;
+    this.transcribingChange.emit(value);
   }
 }

--- a/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.html
+++ b/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.html
@@ -8,15 +8,13 @@
       class="voice-input"
       [label]="isHistoryClarify ? 'Текст' : 'Описание'"
       [control]="noteControl!"
-      [isRecording]="!!recorder"
       [disabled]="transcribing"
       [minRows]="4"
       [maxRows]="12"
       [idleHint]="'Удерживайте для записи'"
       [recordingHint]="'Запись… отпустите, чтобы остановить'"
       (cleared)="clearNote()"
-      (startRecord)="startRecord($event)"
-      (stopRecord)="stopRecord()">
+      (transcribingChange)="onTranscribingChange($event)">
     </app-voice-input-panel>
 
     <mat-form-field appearance="outline" class="time-field">


### PR DESCRIPTION
## Summary
- move the speech recording and transcription workflow into `VoiceInputPanelComponent`
- surface the panel's transcription state to keep the dialog UI disabled and progress bar in sync
- update `VoiceNoteDialogComponent` to use the refactored panel API

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd43cd066c833199bef8fa18b4ed62