### PR TITLE
Adjust voice input padding to use full width

### DIFF
--- a/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.scss
+++ b/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.scss
@@ -10,7 +10,7 @@
   background: #fff;
   border: 1px solid #e5e7eb;        /* slate-200 */
   border-radius: 28px;               /* «пилюля» */
-  padding: 12px 56px 64px 16px;      /* extra снизу под плавающий микрофон */
+  padding: 12px 16px 64px 16px;      /* extra снизу под плавающий микрофон */
   box-shadow:
     0 1px 2px rgba(0,0,0,.04),
     0 2px 6px rgba(0,0,0,.02);
@@ -36,6 +36,8 @@
   background: transparent;
   font: inherit;
   line-height: 1.4;
+  padding-right: 16px;               /* базовый отступ, без «пустой» колонки */
+  padding-bottom: 56px;              /* чтобы текст не попадал под кнопку микрофона */
 }
 
 .chatgpt-input__textarea::placeholder {


### PR DESCRIPTION
## Summary
- reduce the right padding of the voice input panel so text spans the full width of the dialog
- add internal padding to the textarea to keep content clear of the floating microphone button

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd52835a5c83318233fdf731aeb670