### PR TITLE
Align history detail dialog actions with shared style

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.html
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.html
@@ -90,18 +90,18 @@
     </table>
   </div>
 
-  <div class="buttons">
-    <button mat-raised-button color="primary" (click)="openClarify()">
-      <mat-icon>edit</mat-icon>
-      <span>Уточнить</span>
-    </button>
-    <button mat-button color="warn" (click)="remove()">
+  <div mat-dialog-actions align="end" class="actions">
+    <button mat-button color="warn" type="button" (click)="remove()">
       <mat-icon>delete</mat-icon>
       <span>Удалить</span>
     </button>
-    <button mat-button (click)="dialogRef.close()">
+    <button mat-button type="button" (click)="dialogRef.close()">
       <mat-icon>close</mat-icon>
       <span>Закрыть</span>
+    </button>
+    <button mat-flat-button color="primary" type="button" (click)="openClarify()">
+      <mat-icon>edit</mat-icon>
+      <span>Уточнить</span>
     </button>
   </div>
 </div>

--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
@@ -132,10 +132,12 @@
   .products-table .name { max-width: 240px; }
 }
 
-.buttons {
+.actions {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
-  gap: 6px;
+  gap: 8px;
+  padding-top: 8px;
 
   button {
     display: inline-flex;


### PR DESCRIPTION
## Summary
- replace the history detail dialog button container with `mat-dialog-actions` so the controls mirror other dialogs and keep the same labels/icons
- tweak the dialog action styles to match the shared spacing while preserving the compact icon layout

## Testing
- npm run lint *(fails: Missing script "lint" in mobile/calorie-counter/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6c43d5c0833187c332c63c0f35e0