### PR TITLE
Show full timestamp in history detail dialog

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.html
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.html
@@ -14,9 +14,8 @@
 
   <div class="meta">
     <div class="meta-row">
-      <span class="meta-left">{{ time(data.item.createdAtUtc) }}</span>
-      <span class="dot">·</span>
-      <span class="meta-right">{{ data.item.caloriesKcal ?? '—' }} ккал</span>
+      <span class="meta-left">{{ formatDateTime(data.item.createdAtUtc) }}</span>
+      <span class="meta-right">Калории: {{ data.item.caloriesKcal ?? '—' }} ккал</span>
     </div>
 
     <div class="chips">

--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
@@ -52,16 +52,20 @@
 
 .meta-row {
   display: inline-flex;
-  align-items: baseline;
-  gap: 6px;
+  align-items: flex-start;
+  column-gap: 6px;
+  row-gap: 2px;
+  flex-wrap: wrap;
   font-size: 15px;
   line-height: 1.25;
   font-weight: 500;
 }
 
 .meta-left { opacity: .9; }
-.meta-right { opacity: .85; font-weight: 500; }
-.meta-row .dot { opacity: .5; }
+.meta-right {
+  opacity: .85;
+  font-weight: 500;
+}
 
 .chips {
   display: flex;

--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.ts
@@ -53,8 +53,20 @@ export class HistoryDetailDialogComponent implements OnInit {
     this.fitDialog();
   }
 
-  time(s: string) {
-    return new Date(s).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  formatDateTime(value: string) {
+    if (!value) {
+      return '—';
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '—';
+    }
+
+    return date.toLocaleString([], {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    });
   }
 
   /** Аккуратно подгоняет высоту диалога под контент */


### PR DESCRIPTION
## Summary
- format history entry timestamps with localized date and time
- update dialog markup to reference the new formatter and clarify the calorie label
- tweak meta-row flex layout so the longer timestamp wraps cleanly on small screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd7e5d87b8833180e41986fca770fc