### PR TITLE
Adjust camera preview aspect and capture quality

### DIFF
--- a/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.scss
+++ b/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.scss
@@ -13,7 +13,7 @@
   background: #000;
   border-radius: 16px;
   overflow: hidden;
-  aspect-ratio: 3 / 4;
+  aspect-ratio: var(--camera-aspect, 3 / 4);
   max-height: calc(100dvh - 160px);
   min-height: 280px;
 }


### PR DESCRIPTION
## Summary
- derive the preview box ratio from the device screen and expose it through a CSS variable so the live camera view matches the native camera proportions
- request the high-resolution stream when starting the preview and defer picture dimensions to the plugin defaults to capture at the device quality level

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd970ef02c83319c175ec8ade00236