### PR TITLE
Fix camera preview permissions on Android

### DIFF
--- a/mobile/calorie-counter/android/app/src/main/AndroidManifest.xml
+++ b/mobile/calorie-counter/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <!-- Ðàçðåøåíèÿ -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <!-- ÃÃ Ã§Ã°Ã¥Ã¸Ã¥Ã­Ã¨Ã¿ -->
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application


### PR DESCRIPTION
## Summary
- add the missing CAMERA permission to the Android manifest so the native preview can initialize
- request camera access through Capacitor before starting the preview and fall back to the system camera if it is denied

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd9df1a8e88331b77477bc66b97096