### PR TITLE
Fix zoom constraint typing for DOM preview

### DIFF
--- a/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.ts
+++ b/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.ts
@@ -41,6 +41,14 @@ type NextClarifyDraft = {
   time?: string;
 };
 
+type ZoomMediaTrackConstraints = MediaTrackConstraints & {
+  zoom?: ConstrainDoubleRange;
+};
+
+type ZoomMediaTrackConstraintSet = MediaTrackConstraintSet & {
+  zoom?: number;
+};
+
 @Component({
   selector: "app-add-meal",
   standalone: true,
@@ -365,8 +373,12 @@ export class AddMealPage implements OnInit, AfterViewInit, OnDestroy {
     this.previewStarting = true;
 
     // Базовые ограничения — задняя камера и без звука
+    const videoConstraints: ZoomMediaTrackConstraints = {
+      facingMode: { ideal: "environment" },
+      zoom: { ideal: 1 }
+    };
     const base: MediaStreamConstraints = {
-      video: { facingMode: { ideal: "environment" }, zoom: { ideal: 1 } },
+      video: videoConstraints,
       audio: false
     };
 
@@ -394,7 +406,9 @@ export class AddMealPage implements OnInit, AfterViewInit, OnDestroy {
           zoomCap.max >= 1
         ) {
           try {
-            await track.applyConstraints({ advanced: [{ zoom: 1 }] });
+            const zoomConstraint: ZoomMediaTrackConstraintSet = { zoom: 1 };
+            const zoomApplyConstraints: MediaTrackConstraints = { advanced: [zoomConstraint] };
+            await track.applyConstraints(zoomApplyConstraints);
           } catch {
             // ignore zoom errors on devices without support
           }


### PR DESCRIPTION
## Summary
- add helper types to describe zoom-capable media constraints
- reuse the helper types when requesting and applying zoom so TypeScript accepts the constraints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdb3981fec8331bc425d083c36b372