### PR TITLE
Add microphone permission to Android manifest

### DIFF
--- a/mobile/calorie-counter/android/app/src/main/AndroidManifest.xml
+++ b/mobile/calorie-counter/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <!-- Ðàçðåøåíèÿ -->
     <uses-permission android:name="android.permission.INTERNET" />
 


### PR DESCRIPTION
## Summary
- add the Android RECORD_AUDIO permission so the app can access the microphone during speech recognition

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdb94dd954833193e88b2cbf02c1a1