### PR TITLE
Keep voice input panel background light in dark mode

### DIFF
--- a/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.scss
+++ b/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.scss
@@ -119,7 +119,7 @@
 /* ---------- Тёмная тема (опционально) ---------- */
 @media (prefers-color-scheme: dark) {
   .chatgpt-input {
-    background: #111214;
+    background: var(--mat-sys-surface, #fff);
     border-color: #2a2d33;
 
     &:focus-within { box-shadow: 0 0 0 4px rgba(148, 163, 184, .10); }


### PR DESCRIPTION
## Summary
- keep the voice input panel background tied to the surface token even in dark mode so it stays light

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdb9faa47883319d0cf56f2f577405