### PR TITLE
Handle microphone permissions before recording

### DIFF
--- a/mobile/calorie-counter/src/app/services/voice.service.ts
+++ b/mobile/calorie-counter/src/app/services/voice.service.ts
@@ -12,16 +12,23 @@ export class VoiceService {
     } catch { return false; }
   }
 
-  async ensurePermission() {
-    const status: any = await SpeechRecognition.checkPermissions();
-    const granted = status?.speechRecognition === 'granted' || status?.permission === 'granted';
-    if (!granted) {
-      await SpeechRecognition.requestPermissions();
+  async ensurePermission(): Promise<boolean> {
+    try {
+      const status: any = await SpeechRecognition.checkPermissions();
+      let granted = status?.speechRecognition === 'granted' || status?.permission === 'granted';
+      if (!granted) {
+        const requested: any = await SpeechRecognition.requestPermissions();
+        granted = requested?.speechRecognition === 'granted' || requested?.permission === 'granted';
+      }
+      return !!granted;
+    } catch {
+      return false;
     }
   }
 
   async listenOnce(lang: string = 'ru-RU'): Promise<string> {
-    await this.ensurePermission();
+    const granted = await this.ensurePermission();
+    if (!granted) return '';
     if (this.listening) await SpeechRecognition.stop();
     this.listening = true;
 


### PR DESCRIPTION
## Summary
- inject the voice service into the voice input panel so microphone permission can be requested before recording
- require a positive permission check before accessing getUserMedia and show a friendly hint when access is denied
- harden the shared voice service permission helper to return a boolean result and respect it during speech recognition

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdbd491c4c833181ac43d06ccaa627