### PR TITLE
Add transcription spinner to voice input panel

### DIFF
--- a/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.html
+++ b/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.html
@@ -24,7 +24,12 @@
           (mouseleave)="onRelease()"
           (touchend)="onRelease()"
           (touchcancel)="onRelease()">
-    <mat-icon>{{ isRecording ? 'mic' : 'mic_none' }}</mat-icon>
+    <mat-icon *ngIf="!transcribing">{{ isRecording ? 'mic' : 'mic_none' }}</mat-icon>
+    <mat-progress-spinner *ngIf="transcribing"
+                          class="chatgpt-input__spinner"
+                          mode="indeterminate"
+                          diameter="24"
+                          strokeWidth="3"></mat-progress-spinner>
   </button>
 </div>
 

--- a/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.scss
+++ b/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.scss
@@ -96,6 +96,11 @@
   }
 }
 
+.chatgpt-input__spinner {
+  width: 24px;
+  height: 24px;
+}
+
 /* во время записи — явная подсветка микрофона */
 .chatgpt-input--recording .chatgpt-input__mic {
   background: #ef4444 !important;

--- a/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.ts
+++ b/mobile/calorie-counter/src/app/components/voice-input-panel/voice-input-panel.component.ts
@@ -5,6 +5,7 @@ import { MatInputModule } from "@angular/material/input";
 import { MatIconModule } from "@angular/material/icon";
 import { MatButtonModule } from "@angular/material/button";
 import { MatTooltipModule } from "@angular/material/tooltip";
+import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
 import { TextFieldModule } from "@angular/cdk/text-field";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { MatSnackBar } from "@angular/material/snack-bar";
@@ -24,7 +25,8 @@ import { VoiceService } from "../../services/voice.service";
     MatIconModule,
     MatButtonModule,
     MatTooltipModule,
-    TextFieldModule
+    TextFieldModule,
+    MatProgressSpinnerModule
   ],
   templateUrl: "./voice-input-panel.component.html",
   styleUrls: ["./voice-input-panel.component.scss"],


### PR DESCRIPTION
## Summary
- replace the microphone icon with an indeterminate progress spinner while voice transcription is in progress
- style the spinner to fit inside the microphone button and import the Angular Material spinner module

## Testing
- `npm test -- --watch=false` *(fails: Chrome browser binary is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce1df6298c8331aa33e96507e2e8ab