### PR TITLE
Add modify audio settings permission to Android

### DIFF
--- a/mobile/calorie-counter/android/app/capacitor.build.gradle
+++ b/mobile/calorie-counter/android/app/capacitor.build.gradle
@@ -11,10 +11,13 @@ apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-community-camera-preview')
     implementation project(':capacitor-community-speech-recognition')
+    implementation project(':capacitor-app')
     implementation project(':capacitor-camera')
     implementation project(':capacitor-filesystem')
     implementation project(':capacitor-preferences')
     implementation project(':capacitor-status-bar')
+    implementation project(':capgo-capacitor-navigation-bar')
+    implementation project(':capacitor-plugin-safe-area')
 
 }
 

--- a/mobile/calorie-counter/android/app/src/main/AndroidManifest.xml
+++ b/mobile/calorie-counter/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <!-- Ðàçðåøåíèÿ -->
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/mobile/calorie-counter/android/capacitor.settings.gradle
+++ b/mobile/calorie-counter/android/capacitor.settings.gradle
@@ -8,6 +8,9 @@ project(':capacitor-community-camera-preview').projectDir = new File('../node_mo
 include ':capacitor-community-speech-recognition'
 project(':capacitor-community-speech-recognition').projectDir = new File('../node_modules/@capacitor-community/speech-recognition/android')
 
+include ':capacitor-app'
+project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
+
 include ':capacitor-camera'
 project(':capacitor-camera').projectDir = new File('../node_modules/@capacitor/camera/android')
 
@@ -19,3 +22,9 @@ project(':capacitor-preferences').projectDir = new File('../node_modules/@capaci
 
 include ':capacitor-status-bar'
 project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')
+
+include ':capgo-capacitor-navigation-bar'
+project(':capgo-capacitor-navigation-bar').projectDir = new File('../node_modules/@capgo/capacitor-navigation-bar/android')
+
+include ':capacitor-plugin-safe-area'
+project(':capacitor-plugin-safe-area').projectDir = new File('../node_modules/capacitor-plugin-safe-area/android')


### PR DESCRIPTION
## Summary
- add the MODIFY_AUDIO_SETTINGS permission to the Android manifest so audio adjustments can be managed in-app
- sync the Capacitor Android project which updated generated Gradle plugin references

## Testing
- `npx cap sync android`
- `./gradlew assembleDebug` *(fails: Android SDK location not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce202c54088331bec0256ceeafb82f