### PR TITLE
Fix Android safe area padding density

### DIFF
--- a/mobile/calorie-counter/android/app/src/main/java/com/yourscriptor/calorie/MainActivity.java
+++ b/mobile/calorie-counter/android/app/src/main/java/com/yourscriptor/calorie/MainActivity.java
@@ -14,9 +14,16 @@ public class MainActivity extends BridgeActivity {
     setTheme(R.style.AppTheme_NoActionBar);
     WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
     View rootView = findViewById(android.R.id.content);
+    final float density = getResources().getDisplayMetrics().density;
     ViewCompat.setOnApplyWindowInsetsListener(rootView, (v, insets) -> {
       int bottom = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
-      bridge.getWebView().evaluateJavascript("document.body.style.paddingBottom='" + bottom + "px';", null);
+      float cssBottom = bottom / density;
+      bridge
+        .getWebView()
+        .evaluateJavascript(
+          "document.body.style.paddingBottom='" + cssBottom + "px';",
+          null
+        );
       return insets;
     });
     ViewCompat.requestApplyInsets(rootView);


### PR DESCRIPTION
## Summary
- convert system bar inset passed from Android to CSS pixels by dividing by display density
- apply the corrected value when updating the WebView padding

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce23da9bdc833189e41dbe4fab4d36