### PR TITLE
Adjust webview scaling to match browser baseline

### DIFF
--- a/mobile/calorie-counter/android/app/src/main/java/com/yourscriptor/calorie/MainActivity.java
+++ b/mobile/calorie-counter/android/app/src/main/java/com/yourscriptor/calorie/MainActivity.java
@@ -2,6 +2,8 @@ package com.yourscriptor.calorie;
 
 import android.os.Bundle;
 import android.view.View;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
@@ -14,16 +16,26 @@ public class MainActivity extends BridgeActivity {
     setTheme(R.style.AppTheme_NoActionBar);
     WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
     View rootView = findViewById(android.R.id.content);
+    final WebView webView = bridge.getWebView();
+
+    if (webView != null) {
+      WebSettings webSettings = webView.getSettings();
+      webSettings.setUseWideViewPort(true);
+      webSettings.setLoadWithOverviewMode(true);
+      webSettings.setTextZoom(100);
+      webView.setInitialScale(100);
+    }
+
     final float density = getResources().getDisplayMetrics().density;
     ViewCompat.setOnApplyWindowInsetsListener(rootView, (v, insets) -> {
       int bottom = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
       float cssBottom = bottom / density;
-      bridge
-        .getWebView()
-        .evaluateJavascript(
+      if (webView != null) {
+        webView.evaluateJavascript(
           "document.body.style.paddingBottom='" + cssBottom + "px';",
           null
         );
+      }
       return insets;
     });
     ViewCompat.requestApplyInsets(rootView);


### PR DESCRIPTION
## Summary
- configure the Android WebView to use the mobile browser viewport defaults
- ensure the WebView keeps a 1:1 CSS pixel scale and preserve padding updates safely

## Testing
- ./gradlew lint --console=plain *(fails: capacitor-cordova-android-plugins/cordova.variables.gradle missing)*
- ./gradlew assembleDebug --console=plain *(fails: capacitor-cordova-android-plugins/cordova.variables.gradle missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2d930f4c8331844a79eb530a6db0