### PR TITLE
Add date-based analysis report generation

### DIFF
--- a/FoodBot/Services/Reports/IReportDataLoader.cs
+++ b/FoodBot/Services/Reports/IReportDataLoader.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using FoodBot.Models;
@@ -6,5 +7,9 @@ namespace FoodBot.Services.Reports;
 
 public interface IReportDataLoader<TData>
 {
-    Task<ReportData<TData>> LoadAsync(long chatId, AnalysisPeriod period, CancellationToken ct);
+    Task<ReportData<TData>> LoadAsync(
+        long chatId,
+        AnalysisPeriod period,
+        CancellationToken ct,
+        DateOnly? periodStartLocalDate = null);
 }

--- a/FoodBot/Services/Reports/IReportStrategy.cs
+++ b/FoodBot/Services/Reports/IReportStrategy.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using FoodBot.Models;
@@ -11,7 +12,7 @@ public interface IReportStrategy<TData>
     /// <summary>
     /// Load structured report data for the given chat and period.
     /// </summary>
-    Task<ReportData<TData>> LoadDataAsync(long chatId, CancellationToken ct);
+    Task<ReportData<TData>> LoadDataAsync(long chatId, DateOnly? periodStartLocalDate, CancellationToken ct);
 
     /// <summary>
     /// Build a prompt from the loaded report data.

--- a/FoodBot/Services/Reports/ReportDataLoaderBase.cs
+++ b/FoodBot/Services/Reports/ReportDataLoaderBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,9 +12,13 @@ namespace FoodBot.Services.Reports;
 public abstract class ReportDataLoaderBase<TData> : IReportDataLoader<TData>
 {
     /// <inheritdoc />
-    public async Task<ReportData<TData>> LoadAsync(long chatId, AnalysisPeriod period, CancellationToken ct)
+    public async Task<ReportData<TData>> LoadAsync(
+        long chatId,
+        AnalysisPeriod period,
+        CancellationToken ct,
+        DateOnly? periodStartLocalDate = null)
     {
-        var (payload, periodHuman) = await LoadCoreAsync(chatId, period, ct);
+        var (payload, periodHuman) = await LoadCoreAsync(chatId, period, ct, periodStartLocalDate);
         return new ReportData<TData>
         {
             Data = payload,
@@ -25,5 +30,9 @@ public abstract class ReportDataLoaderBase<TData> : IReportDataLoader<TData>
     /// <summary>
     /// Implemented by derived classes to load the payload for the specified chat and period.
     /// </summary>
-    protected abstract Task<(TData Data, string PeriodHuman)> LoadCoreAsync(long chatId, AnalysisPeriod period, CancellationToken ct);
+    protected abstract Task<(TData Data, string PeriodHuman)> LoadCoreAsync(
+        long chatId,
+        AnalysisPeriod period,
+        CancellationToken ct,
+        DateOnly? periodStartLocalDate = null);
 }

--- a/FoodBot/Services/Reports/ReportStrategy.cs
+++ b/FoodBot/Services/Reports/ReportStrategy.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using FoodBot.Models;
@@ -21,8 +22,8 @@ public sealed class ReportStrategy<TData> : IReportStrategy<TData>
 
     public AnalysisPeriod Period { get; }
 
-    public async Task<ReportData<TData>> LoadDataAsync(long chatId, CancellationToken ct)
-        => await _loader.LoadAsync(chatId, Period, ct);
+    public async Task<ReportData<TData>> LoadDataAsync(long chatId, DateOnly? periodStartLocalDate, CancellationToken ct)
+        => await _loader.LoadAsync(chatId, Period, ct, periodStartLocalDate);
 
     public string BuildPrompt(ReportData<TData> data)
         => _promptBuilder.Build(data);

--- a/mobile/calorie-counter/src/app/pages/analysis/analysis-date-dialog.component.ts
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis-date-dialog.component.ts
@@ -1,0 +1,77 @@
+import { Component, Inject, Optional } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { MatInputModule } from '@angular/material/input';
+
+interface DialogData {
+  defaultDate?: Date;
+}
+
+@Component({
+  selector: 'app-analysis-date-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatInputModule
+  ],
+  template: `
+    <h2 mat-dialog-title>Создать отчёт от даты</h2>
+    <mat-dialog-content>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Дата</mat-label>
+        <input matInput [matDatepicker]="picker" [(ngModel)]="selectedDate" />
+        <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
+        <mat-datepicker #picker></mat-datepicker>
+      </mat-form-field>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button (click)="cancel()">Отмена</button>
+      <button mat-flat-button color="primary" [disabled]="!selectedDate" (click)="confirm()">
+        Создать
+      </button>
+    </mat-dialog-actions>
+  `,
+  styles: [
+    `
+      .full-width {
+        width: 100%;
+      }
+    `
+  ]
+})
+export class AnalysisDateDialogComponent {
+  selectedDate: Date | null;
+
+  constructor(
+    private readonly dialogRef: MatDialogRef<AnalysisDateDialogComponent, Date | null>,
+    @Optional() @Inject(MAT_DIALOG_DATA) data: DialogData | null
+  ) {
+    const initial = data?.defaultDate ? new Date(data.defaultDate) : new Date();
+    initial.setHours(0, 0, 0, 0);
+    this.selectedDate = initial;
+  }
+
+  cancel() {
+    this.dialogRef.close(null);
+  }
+
+  confirm() {
+    if (!this.selectedDate) {
+      return;
+    }
+    const normalized = new Date(this.selectedDate);
+    normalized.setHours(0, 0, 0, 0);
+    this.dialogRef.close(normalized);
+  }
+}

--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.html
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.html
@@ -18,6 +18,17 @@
       <button mat-menu-item (click)="create('quarter')">Квартал</button>
     </mat-menu>
 
+    <button
+      mat-button
+      class="toolbar-action"
+      color="primary"
+      [disabled]="hasProcessing || loading"
+      (click)="createFromDate()"
+    >
+      <mat-icon>event</mat-icon>
+      <span>Создать от даты</span>
+    </button>
+
     <button mat-button class="toolbar-action" color="accent" (click)="refresh()">
       <mat-icon>refresh</mat-icon>
       <span>Обновить</span>

--- a/mobile/calorie-counter/src/app/services/analysis.service.ts
+++ b/mobile/calorie-counter/src/app/services/analysis.service.ts
@@ -54,9 +54,14 @@ export class AnalysisService {
   }
 
   /** Создать новый отчёт указанного периода */
-  create(period: AnalysisPeriod): Promise<CreateReportResponse> {
+  create(period: AnalysisPeriod, options?: { date?: Date }): Promise<CreateReportResponse> {
+    const payload: { period: AnalysisPeriod; date?: string } = { period };
+    if (options?.date) {
+      payload.date = this.formatDate(options.date);
+    }
+
     return firstValueFrom(
-      this.http.post<CreateReportResponse>(`${this.baseUrl}/api/analysis`, { period })
+      this.http.post<CreateReportResponse>(`${this.baseUrl}/api/analysis`, payload)
     );
   }
 
@@ -93,5 +98,14 @@ export class AnalysisService {
       filter(x => !!x),
       take(1)
     );
+  }
+
+  private formatDate(date: Date): string {
+    const normalized = new Date(date);
+    normalized.setHours(0, 0, 0, 0);
+    const year = normalized.getFullYear();
+    const month = (normalized.getMonth() + 1).toString().padStart(2, '0');
+    const day = normalized.getDate().toString().padStart(2, '0');
+    return `${year}-${month}-${day}`;
   }
 }


### PR DESCRIPTION
## Summary
- allow requesting daily analysis reports for a specified date by extending the API
- adjust report generation services to respect stored period start dates when loading data and computing checksums
- add an Angular dialog on the analysis page to pick a date and trigger report creation

## Testing
- npm run build
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf9a933c1c8331a90410c04c69a1ed