### PR TITLE
Enable report type selection in analysis date dialog

### DIFF
--- a/mobile/calorie-counter/src/app/pages/analysis/analysis-date-dialog.component.ts
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis-date-dialog.component.ts
@@ -7,9 +7,18 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatIconModule } from '@angular/material/icon';
+import { AnalysisPeriod } from '../../services/analysis.service';
 
 interface DialogData {
   defaultDate?: Date;
+  defaultPeriod?: AnalysisPeriod;
+}
+
+interface DialogResult {
+  date: Date;
+  period: AnalysisPeriod;
 }
 
 @Component({
@@ -23,17 +32,30 @@ interface DialogData {
     MatFormFieldModule,
     MatDatepickerModule,
     MatNativeDateModule,
-    MatInputModule
+    MatInputModule,
+    MatSelectModule,
+    MatIconModule
   ],
   template: `
     <h2 mat-dialog-title>Создать отчёт от даты</h2>
     <mat-dialog-content>
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Дата</mat-label>
-        <input matInput [matDatepicker]="picker" [(ngModel)]="selectedDate" />
-        <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
-        <mat-datepicker #picker></mat-datepicker>
-      </mat-form-field>
+      <div class="fields">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Тип отчёта</mat-label>
+          <mat-select [(ngModel)]="selectedPeriod">
+            <mat-option *ngFor="let option of periods" [value]="option.value">
+              {{ option.label }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Дата</mat-label>
+          <input matInput [matDatepicker]="picker" [(ngModel)]="selectedDate" />
+          <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
+          <mat-datepicker #picker></mat-datepicker>
+        </mat-form-field>
+      </div>
     </mat-dialog-content>
     <mat-dialog-actions align="end">
       <button mat-button (click)="cancel()">Отмена</button>
@@ -44,6 +66,12 @@ interface DialogData {
   `,
   styles: [
     `
+      .fields {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
       .full-width {
         width: 100%;
       }
@@ -52,14 +80,24 @@ interface DialogData {
 })
 export class AnalysisDateDialogComponent {
   selectedDate: Date | null;
+  selectedPeriod: AnalysisPeriod;
+
+  readonly periods: Array<{ value: AnalysisPeriod; label: string }> = [
+    { value: 'day', label: 'День · итог' },
+    { value: 'dayRemainder', label: 'День · остаток' },
+    { value: 'week', label: 'Неделя' },
+    { value: 'month', label: 'Месяц' },
+    { value: 'quarter', label: 'Квартал' }
+  ];
 
   constructor(
-    private readonly dialogRef: MatDialogRef<AnalysisDateDialogComponent, Date | null>,
+    private readonly dialogRef: MatDialogRef<AnalysisDateDialogComponent, DialogResult | null>,
     @Optional() @Inject(MAT_DIALOG_DATA) data: DialogData | null
   ) {
     const initial = data?.defaultDate ? new Date(data.defaultDate) : new Date();
     initial.setHours(0, 0, 0, 0);
     this.selectedDate = initial;
+    this.selectedPeriod = data?.defaultPeriod ?? 'day';
   }
 
   cancel() {
@@ -72,6 +110,9 @@ export class AnalysisDateDialogComponent {
     }
     const normalized = new Date(this.selectedDate);
     normalized.setHours(0, 0, 0, 0);
-    this.dialogRef.close(normalized);
+    this.dialogRef.close({
+      date: normalized,
+      period: this.selectedPeriod
+    });
   }
 }

--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.ts
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.ts
@@ -104,7 +104,7 @@ export class AnalysisPage implements OnInit, OnDestroy {
     const ref = this.dialog.open(AnalysisDateDialogComponent);
     const selected = await firstValueFrom(ref.afterClosed());
     if (!selected) return;
-    await this.create('day', selected);
+    await this.create(selected.period, selected.date);
   }
 
   open(row: ReportRow) {

--- a/mobile/calorie-counter/src/main.ts
+++ b/mobile/calorie-counter/src/main.ts
@@ -8,6 +8,7 @@ import { routes } from "./app/routes";
 import { AuthInterceptor } from "./app/services/auth.interceptor";
 import { Capacitor } from "@capacitor/core";
 import { StatusBar, Style as StatusBarStyle } from "@capacitor/status-bar";
+import { provideNativeDateAdapter } from "@angular/material/core";
 
 // Configure Android status bar
 (async () => {
@@ -24,6 +25,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideRouter(routes),
     provideAnimations(),
+    provideNativeDateAdapter(),
     provideHttpClient(withInterceptorsFromDi()),
     { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true }
   ]


### PR DESCRIPTION
## Summary
- allow choosing the report period inside the analysis date dialog and pass it back to the creator
- normalize the dialog layout and keep the datepicker toggle functional by including the needed material modules
- provide the native date adapter at bootstrap so the calendar popup opens reliably

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfa3fb092c8331983947be90915b86