### PR TITLE
Restart camera preview after cancelling system camera

### DIFF
--- a/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.ts
+++ b/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.ts
@@ -152,6 +152,10 @@ export class AddMealPage implements OnInit, AfterViewInit, OnDestroy {
   }
   // системная камера (Capacitor Camera)
   async takePhotoSystem() {
+    const hadDomPreview = this.previewActive || this.previewStarting || !!this.mediaStream;
+    if (hadDomPreview) {
+      await this.stopPreview();
+    }
     try {
       const img = await Camera.getPhoto({ quality: 80, resultType: CameraResultType.Base64, source: CameraSource.Camera });
       if (img.base64String) {
@@ -159,6 +163,10 @@ export class AddMealPage implements OnInit, AfterViewInit, OnDestroy {
       }
     } catch (err) {
       this.handleCameraError(err, "Не удалось сделать фото");
+    } finally {
+      if (hadDomPreview) {
+        await this.startPreviewWithFallback();
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- stop the DOM preview before launching the system camera so Capacitor can take control
- restart the DOM preview after the system camera closes when it was previously active

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfc14ace98833192148c3b753022fc