### PR TITLE
feat: add camera cycling controls

### DIFF
--- a/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.html
+++ b/mobile/calorie-counter/src/app/pages/add-meal/add-meal.page.html
@@ -13,7 +13,11 @@
       <button mat-mini-fab color="accent" (click)="openNextClarifyDialog()"
               matTooltip="Добавить уточнение к следующему фото" aria-label="Уточнение к следующему фото">
         <mat-icon>note_add</mat-icon>
-      </button>      
+      </button>
+      <button mat-mini-fab color="primary" (click)="switchCamera()"
+              matTooltip="Переключить камеру" aria-label="Переключить камеру">
+        <mat-icon>cameraswitch</mat-icon>
+      </button>
       <button mat-fab color="primary" (click)="captureFromPreview()" matTooltip="Сделать фото" aria-label="Сделать фото">
         <mat-icon>camera</mat-icon>
       </button>
@@ -32,6 +36,10 @@
       <button mat-mini-fab color="accent" (click)="openNextClarifyDialog()"
               matTooltip="Добавить уточнение к следующему фото" aria-label="Уточнение к следующему фото">
         <mat-icon>note_add</mat-icon>
+      </button>
+      <button mat-mini-fab color="primary" (click)="switchCamera()"
+              matTooltip="Переключить камеру" aria-label="Переключить камеру">
+        <mat-icon>cameraswitch</mat-icon>
       </button>
       <button mat-raised-button color="primary" (click)="retryPreview()">
         <mat-icon>autorenew</mat-icon>


### PR DESCRIPTION
## Summary
- add a camera switch control to the Add Meal preview overlays
- reuse enumerated camera list to cycle through devices and track the active one
- display detailed camera characteristics in an alert whenever the preview switches

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfcbf980948331aa53ac5624c28269