### PR TITLE
Add retry logic for OpenAI analysis requests

### DIFF
--- a/FoodBot/Services/Analysis/AnalysisGenerator.cs
+++ b/FoodBot/Services/Analysis/AnalysisGenerator.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -19,37 +20,75 @@ public sealed class AnalysisGenerator
 
     public async Task<string> GenerateAsync(string body, CancellationToken ct)
     {
+        const int maxAttempts = 3;
+        var delay = TimeSpan.FromSeconds(2);
         var http = _httpFactory.CreateClient();
-        using var msg = new HttpRequestMessage(HttpMethod.Post, "https://api.openai.com/v1/responses");
-        msg.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
-        msg.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        Exception? lastException = null;
 
-        using var resp = await http.SendAsync(msg, ct);
-        resp.EnsureSuccessStatusCode();
-        var respText = await resp.Content.ReadAsStringAsync(ct);
-
-        using var doc = JsonDocument.Parse(respText);
-        if (!doc.RootElement.TryGetProperty("output", out var output))
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
-            return string.Empty;
+            try
+            {
+                using var msg = new HttpRequestMessage(HttpMethod.Post, "https://api.openai.com/v1/responses");
+                msg.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+                msg.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+                using var resp = await http.SendAsync(msg, ct);
+
+                if (!resp.IsSuccessStatusCode)
+                {
+                    if (attempt == maxAttempts || !IsTransient(resp.StatusCode))
+                    {
+                        resp.EnsureSuccessStatusCode();
+                    }
+                    else
+                    {
+                        await Task.Delay(delay, ct);
+                        delay = TimeSpan.FromSeconds(delay.TotalSeconds * 2);
+                        continue;
+                    }
+                }
+
+                var respText = await resp.Content.ReadAsStringAsync(ct);
+
+                using var doc = JsonDocument.Parse(respText);
+                if (!doc.RootElement.TryGetProperty("output", out var output))
+                {
+                    return string.Empty;
+                }
+
+                var message = output.EnumerateArray()
+                    .FirstOrDefault(e => e.TryGetProperty("type", out var t) && t.GetString() == "message");
+
+                if (message.ValueKind == JsonValueKind.Undefined)
+                {
+                    return string.Empty;
+                }
+
+                if (!message.TryGetProperty("content", out var contentArr) || contentArr.ValueKind != JsonValueKind.Array || contentArr.GetArrayLength() == 0)
+                {
+                    return string.Empty;
+                }
+
+                var text = contentArr[0].GetProperty("text").GetString();
+
+                return text ?? string.Empty;
+            }
+            catch (HttpRequestException ex) when (attempt < maxAttempts)
+            {
+                lastException = ex;
+                await Task.Delay(delay, ct);
+                delay = TimeSpan.FromSeconds(delay.TotalSeconds * 2);
+            }
         }
 
-        var message = output.EnumerateArray()
-            .FirstOrDefault(e => e.TryGetProperty("type", out var t) && t.GetString() == "message");
+        throw lastException ?? new InvalidOperationException("Failed to generate analysis response.");
+    }
 
-        if (message.ValueKind == JsonValueKind.Undefined)
-        {
-            return string.Empty;
-        }
-
-        if (!message.TryGetProperty("content", out var contentArr) || contentArr.ValueKind != JsonValueKind.Array || contentArr.GetArrayLength() == 0)
-        {
-            return string.Empty;
-        }
-
-        var text = contentArr[0].GetProperty("text").GetString();
-
-        return text ?? string.Empty;
+    private static bool IsTransient(HttpStatusCode statusCode)
+    {
+        return statusCode == HttpStatusCode.TooManyRequests
+            || (int)statusCode >= 500;
     }
 }
 


### PR DESCRIPTION
## Summary
- add retry logic with exponential backoff when calling the OpenAI responses endpoint
- treat transient HTTP status codes as retryable to reduce failures when the API is unavailable

## Testing
- `dotnet test` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d00bc94188833192c3b6f3a076b608