### PR TITLE
Remove analysis page loading spinner

### DIFF
--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.html
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.html
@@ -82,6 +82,4 @@
 
     <div *ngIf="rows.length === 0 && !loading" class="empty">Пока нет сохранённых отчётов.</div>
   </mat-card>
-
-  <mat-spinner *ngIf="rows.length < allRows.length"></mat-spinner>
 </div>

--- a/mobile/calorie-counter/src/app/pages/analysis/analysis.page.ts
+++ b/mobile/calorie-counter/src/app/pages/analysis/analysis.page.ts
@@ -7,7 +7,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { AnalysisService, AnalysisPeriod, ReportRow } from '../../services/analysis.service';
@@ -28,7 +27,6 @@ import { AnalysisDateDialogComponent } from './analysis-date-dialog.component';
     MatMenuModule,
     MatChipsModule,
     MatSnackBarModule,
-    MatProgressSpinnerModule,
     MatDialogModule,
     InfiniteScrollModule
   ],


### PR DESCRIPTION
## Summary
- remove the redundant spinner from the analysis history view
- drop the unused Angular Material progress spinner module import

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0114b6e508331b39b6402f7b79926