### PR TITLE
Add history image placeholders to avoid layout shift

### DIFF
--- a/mobile/calorie-counter/src/app/pages/history/history.page.html
+++ b/mobile/calorie-counter/src/app/pages/history/history.page.html
@@ -22,8 +22,13 @@
     <mat-card class="meal-card" (click)="openDialog(m)" tabindex="0" aria-label="Открыть карточку приёма">
       <div class="meal-card__grid">
         <!-- Фото без отступов: заполняет всю левую полосу карточки, квадрат по полной высоте -->
-        <div class="meal-card__thumb" *ngIf="m.hasImage && imgUrl(m.id)">
-          <img [src]="imgUrl(m.id)" alt="Фото блюда" loading="lazy" decoding="async">
+        <div class="meal-card__thumb" *ngIf="m.hasImage">
+          <ng-container *ngIf="imgUrl(m.id) as url; else thumbPlaceholder">
+            <img [src]="url" alt="Фото блюда" loading="lazy" decoding="async">
+          </ng-container>
+          <ng-template #thumbPlaceholder>
+            <div class="meal-card__thumb-placeholder" aria-hidden="true"></div>
+          </ng-template>
         </div>
 
         <!-- Контент с внутренними отступами справа -->

--- a/mobile/calorie-counter/src/app/pages/history/history.page.scss
+++ b/mobile/calorie-counter/src/app/pages/history/history.page.scss
@@ -70,6 +70,16 @@
   height: 100%;            /* растянуть на всю высоту карточки */
   aspect-ratio: 1 / 1;     /* сохранить квадратность */
   background: #f3f3f3;     /* подложка на случай отсутствия картинки */
+  display: flex;
+  align-items: stretch;
+
+  &-placeholder {
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(110deg, #f3f3f3 25%, #e7e7e7 37%, #f3f3f3 63%);
+    background-size: 400% 100%;
+    animation: meal-card-thumb-shimmer 1.4s ease-in-out infinite;
+  }
 
   img {
     display: block;
@@ -77,6 +87,11 @@
     height: 100%;
     object-fit: cover;     /* обрезать по контейнеру без искажений */
   }
+}
+
+@keyframes meal-card-thumb-shimmer {
+  0% { background-position: 0% 0; }
+  100% { background-position: -200% 0; }
 }
 
 /* Контент: даем внутренний отступ, раз фото без отступов */


### PR DESCRIPTION
## Summary
- always render the thumbnail column for meals with images and swap in a shimmer placeholder while the blob URL loads
- add styles for the placeholder so the card keeps its dimensions until the real image appears

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0445ad8348331bf48e1fef2974798