### PR TITLE
Use symbolic action buttons in voice note and history dialogs

### DIFF
--- a/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.html
+++ b/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.html
@@ -29,9 +29,28 @@
   </div>
 
   <div mat-dialog-actions class="actions" [class.actions--history]="isHistoryClarify">
-    <button *ngIf="isHistoryClarify" mat-button color="warn" type="button" (click)="remove()">Удалить</button>
+    <button
+      *ngIf="isHistoryClarify"
+      type="button"
+      class="icon-button icon-button--danger"
+      (click)="remove()"
+      aria-label="Удалить запись">
+      <span aria-hidden="true">🗑</span>
+    </button>
     <span class="spacer" *ngIf="isHistoryClarify"></span>
-    <button mat-button type="button" (click)="close()">Отмена</button>
-    <button mat-flat-button color="primary" type="submit" [disabled]="!canSend">Отправить</button>
+    <button
+      type="button"
+      class="icon-button icon-button--neutral"
+      (click)="close()"
+      aria-label="Отменить и закрыть диалог">
+      <span aria-hidden="true">✕</span>
+    </button>
+    <button
+      type="submit"
+      class="icon-button icon-button--primary"
+      [disabled]="!canSend"
+      aria-label="Отправить описание">
+      <span aria-hidden="true">✔</span>
+    </button>
   </div>
 </form>

--- a/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.scss
+++ b/mobile/calorie-counter/src/app/components/voice-note-dialog/voice-note-dialog.component.scss
@@ -45,6 +45,51 @@
   flex: 1;
 }
 
+.icon-button {
+  border: none;
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  color: #1f2937;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.15);
+  transition: transform 0.12s ease, box-shadow 0.12s ease, opacity 0.2s ease;
+}
+
+.icon-button[disabled] {
+  opacity: 0.4;
+  cursor: default;
+  box-shadow: none;
+}
+
+.icon-button:not([disabled]):active {
+  transform: translateY(1px) scale(0.97);
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.2);
+}
+
+.icon-button:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.6);
+  outline-offset: 2px;
+}
+
+.icon-button--primary {
+  color: #2563eb;
+}
+
+.icon-button--neutral {
+  color: #4b5563;
+}
+
+.icon-button--danger {
+  color: #dc2626;
+}
+
 .preview {
   border-radius: 12px;
   background: #f5f7fb;

--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.html
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.html
@@ -90,17 +90,26 @@
   </div>
 
   <div mat-dialog-actions align="end" class="actions">
-    <button mat-button color="warn" type="button" (click)="remove()">
-      <mat-icon>delete</mat-icon>
-      <span>Удалить</span>
+    <button
+      type="button"
+      class="icon-button icon-button--danger"
+      (click)="remove()"
+      aria-label="Удалить запись">
+      <span aria-hidden="true">🗑</span>
     </button>
-    <button mat-button type="button" (click)="dialogRef.close()">
-      <mat-icon>close</mat-icon>
-      <span>Закрыть</span>
+    <button
+      type="button"
+      class="icon-button icon-button--neutral"
+      (click)="dialogRef.close()"
+      aria-label="Закрыть диалог">
+      <span aria-hidden="true">✕</span>
     </button>
-    <button mat-flat-button color="primary" type="button" (click)="openClarify()">
-      <mat-icon>edit</mat-icon>
-      <span>Уточнить</span>
+    <button
+      type="button"
+      class="icon-button icon-button--primary"
+      (click)="openClarify()"
+      aria-label="Уточнить запись">
+      <span aria-hidden="true">✎</span>
     </button>
   </div>
 </div>

--- a/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
+++ b/mobile/calorie-counter/src/app/pages/history/history-detail.dialog.scss
@@ -142,17 +142,49 @@
   justify-content: flex-end;
   gap: 8px;
   padding-top: 8px;
+}
 
-  button {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-  }
+.icon-button {
+  border: none;
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  color: #1f2937;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.15);
+  transition: transform 0.12s ease, box-shadow 0.12s ease, opacity 0.2s ease;
+}
 
-  mat-icon {
-    font-size: 18px;
-    width: 18px;
-    height: 18px;
-    line-height: 18px;
-  }
+.icon-button[disabled] {
+  opacity: 0.4;
+  cursor: default;
+  box-shadow: none;
+}
+
+.icon-button:not([disabled]):active {
+  transform: translateY(1px) scale(0.97);
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.2);
+}
+
+.icon-button:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.6);
+  outline-offset: 2px;
+}
+
+.icon-button--primary {
+  color: #2563eb;
+}
+
+.icon-button--neutral {
+  color: #4b5563;
+}
+
+.icon-button--danger {
+  color: #dc2626;
 }


### PR DESCRIPTION
## Summary
- replace text labels in the voice note dialog actions with symbolic buttons and add accessible labels
- restyle the dialog action buttons to appear as floating symbols with a press animation and contextual colors
- apply the same symbolic icon button treatment to the history detail dialog actions for consistency

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d04cb909608331acd79231a1a64ffd